### PR TITLE
adding skills that do a code connect

### DIFF
--- a/.github/skills/figma-connect-component/SKILL.md
+++ b/.github/skills/figma-connect-component/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: figma-connect-component
+description: User provides a Figma component URL and wants to generate the Code Connect mapping for it.
+---
+# Generate Figma Code Connect for React Components
+
+## When to Use This Skill
+User provides a Figma component URL (or component name) and wants to generate the Code Connect mapping for it.
+
+## Required Inputs
+1. **Figma component identifier** (one of):
+   - Full URL: `https://figma.com/design/{fileKey}/{fileName}?node-id={nodeId}`
+   - File key + node ID: `fileKey: abc123, nodeId: 45:67`
+   - Evidence file path: `.temp/figma-explore/{component}.json` or `.temp/figma-connect-shadcn/{component}.json`
+   - Component name (will search for URL in project files)
+2. **Code component folder path** (e.g., `src/components/Button/Button.tsx`)
+
+## Execution Steps
+
+### 1. Gather Figma Component Data
+
+**Option A: Evidence File Provided (Preferred)**
+
+If an evidence file from `figma-explore` is provided (e.g., `.temp/figma-explore/{component}.json`):
+- Read the JSON file directly
+- Extract: `id` (node ID), `name`, `variants`, `variantProperties`, `componentPropertyDefinitions`
+- The file contains all the variant names and values needed for Code Connect
+
+Example evidence file structure:
+```json
+{
+  "id": "16:1234",
+  "name": "Button",
+  "type": "COMPONENT_SET",
+  "variants": [
+    { "name": "Type=Primary, Size=Small", "id": "16:1235" },
+    { "name": "Type=Primary, Size=Large", "id": "16:1236" }
+  ],
+  "variantProperties": {
+    "Type": ["Primary", "Secondary", "Ghost"],
+    "Size": ["Small", "Medium", "Large"]
+  },
+  "componentPropertyDefinitions": {
+    "Label": { "type": "TEXT", "defaultValue": "Button" },
+    "Show Icon": { "type": "BOOLEAN", "defaultValue": false }
+  }
+}
+```
+
+**Option B: URL/Node ID Provided (MCP Fallback)**
+
+If only a Figma URL or node ID is provided:
+
+1. **Search for existing evidence files** in `.temp/figma-explore/` or `.temp/figma-connect-shadcn/` that match the component name
+2. **If not found, use MCP tools**:
+   - Call `mcp_figma_get_metadata` with `nodeId` and `fileKey`
+   - Call `mcp_figma_get_design_context` with `nodeId` and `fileKey`
+
+### 2. Discover Figma URL (if needed)
+If no URL or evidence file provided, search for it:
+1. Check `{ComponentFolder}/README.md` for "Figma Source" section
+2. Check `specs/**/tasks.md` for component-to-Figma mapping tables
+3. Check `.temp/figma-explore/figma-components-index.json` or `.temp/figma-connect-shadcn/figma-components-index.json` for matching component names
+4. Check prior conversation context for file key
+
+### 3. Read Code Component
+- Read the specified component file
+- Identify: exports, props interface, component name
+
+### 4. Generate Mapping
+- Map Figma properties to code props using `figma.*` helpers
+- Build example JSX template
+- Add appropriate imports
+
+### 5. Write File
+- Output to: `{ComponentFolder}/{ComponentName}.figma.tsx`
+- Raw file content only—no markdown fences
+
+## Rules
+
+### Use Exact Figma Property Names
+**Critical:** Code Connect requires the EXACT property names as they appear in Figma.
+
+- Get exact names from evidence files (`.figma-components/*.json`) or `get_metadata` output
+- Property names like `ButtonType`, `Type`, `Size` must match EXACTLY (case-sensitive)
+- The `get_design_context` MCP tool normalizes to camelCase - **do NOT use those names**
+- Property names are case-sensitive: `Size` ≠ `size`
+
+Example from metadata:
+```
+name="ButtonType=Responsive, Type=Primary, Size=Small"
+```
+Use in Code Connect:
+```tsx
+variant: { ButtonType: 'Responsive' },  // ✅ Exact match
+props: {
+  size: figma.enum('Size', { ... }),    // ✅ Exact match
+  variant: figma.enum('Type', { ... }), // ✅ Exact match
+}
+```
+
+### Only Use Real Figma Properties
+Map based on what exists in Figma:
+- **Component properties** → `figma.boolean()`, `figma.string()`, `figma.instance()`
+- **Variant properties** → `figma.enum()`
+- **Text layers** → `figma.textContent('LayerName')`
+- **Nested instances** → `figma.children('LayerName')` or `figma.children('*')`
+- **Child component props** → `figma.nestedProps('LayerName', { ... })`
+
+**Never invent properties that don't exist in Figma.**
+
+### Value Conventions
+- Drop pseudo-state variants: `hover`, `pressed`, `focused`, `state`, `interaction`
+- Map Figma Title Case to code: `Primary` → `'primary'`, `Small` → `'sm'`
+- Normalize boolean variants: "Yes"/"No", "True"/"False", "On"/"Off" → `true`/`false`
+
+### Critical Constraint: No JavaScript Expressions
+Code Connect snippets are **strings, NOT executed code**.
+
+**NEVER use:**
+```tsx
+{hasIcon && <Icon />}
+{disabled ? 'disabled' : ''}
+{icon || <Fallback />}
+```
+
+**Instead, use mapping objects:**
+```tsx
+figma.boolean('Has Icon', {
+  true: <Icon />,
+  false: undefined
+})
+```
+
+## API Reference
+
+### Basic Helpers
+
+```tsx
+// String property
+figma.string('Label')
+
+// Boolean property (simple)
+figma.boolean('Disabled')
+
+// Boolean with mapping
+figma.boolean('Has Icon', {
+  true: <Icon />,
+  false: undefined
+})
+
+// Conditional string based on boolean
+figma.boolean('Has label', {
+  true: figma.string('Label'),
+  false: undefined
+})
+
+// Enum/Variant property
+figma.enum('Size', {
+  'Small': 'sm',
+  'Medium': 'md',
+  'Large': 'lg'
+})
+
+// Text content from a layer
+figma.textContent('Button Label')
+
+// Instance swap property (nested component)
+figma.instance('Icon')
+
+// Child instances by layer name
+figma.children('Tab')
+figma.children(['Tab 1', 'Tab 2'])
+figma.children('Icon*')  // wildcard
+figma.children('*')      // all children
+```
+
+### Advanced Helpers
+
+```tsx
+// Nested props - access child component's properties on parent
+figma.nestedProps('Button Shape', {
+  size: figma.enum('Size', { ... })
+})
+
+// className builder
+figma.className([
+  'btn-base',
+  figma.enum('Size', { 'Large': 'btn-large' }),
+  figma.boolean('Disabled', { true: 'btn-disabled', false: '' })
+])
+
+// Instance with type inference
+figma.instance<React.FunctionComponent>('Icon')  // Returns component type
+figma.instance<string>('Icon')                    // Returns string ID
+
+// Access nested instance props in parent
+figma.instance('Icon').getProps<{ iconId: string, size: 'sm' | 'lg' }>()
+
+// Custom render for nested instance
+figma.instance('Icon').render<{ id: string }>(props => <CustomIcon id={props.id} />)
+```
+
+### Variant Restrictions
+Use when one Figma component maps to multiple code components:
+
+```tsx
+figma.connect(PrimaryButton, 'https://...', {
+  variant: { Type: 'Primary' },
+  example: () => <PrimaryButton />
+})
+
+figma.connect(SecondaryButton, 'https://...', {
+  variant: { Type: 'Secondary' },
+  example: () => <SecondaryButton />
+})
+
+// Boolean variant restriction
+figma.connect(IconButton, 'https://...', {
+  variant: { 'Has Icon': true },
+  example: () => <IconButton />
+})
+
+// Multiple variant combination
+figma.connect(DangerButton, 'https://...', {
+  variant: { Type: 'Danger', Disabled: true },
+  example: () => <DangerButton />
+})
+```
+
+## Complete Example
+
+```tsx
+import figma from '@figma/code-connect'
+import { Button } from './Button'
+
+figma.connect(Button, 'https://figma.com/design/abc123/File?node-id=1:2', {
+  props: {
+    variant: figma.enum('Variant', {
+      Primary: 'primary',
+      Secondary: 'secondary'
+    }),
+    size: figma.enum('Size', {
+      Small: 'sm',
+      Medium: 'md',
+      Large: 'lg'
+    }),
+    disabled: figma.boolean('Disabled'),
+    label: figma.textContent('Label'),
+    icon: figma.boolean('Has Icon', {
+      true: figma.instance('Icon'),
+      false: undefined
+    })
+  },
+  example: ({ variant, size, disabled, label, icon }) => (
+    <Button variant={variant} size={size} disabled={disabled} icon={icon}>
+      {label}
+    </Button>
+  )
+})
+```
+
+## Icon Connection Patterns
+
+### Icons as JSX Elements
+```tsx
+// Icon component
+figma.connect('https://...icon-url...', {
+  example: () => <IconHeart />
+})
+
+// Parent using the icon
+figma.connect(Button, 'https://...button-url...', {
+  props: {
+    icon: figma.instance('Icon')
+  },
+  example: ({ icon }) => <Button>{icon}</Button>
+})
+// Renders: <Button><IconHeart/></Button>
+```
+
+### Icons as React Components
+```tsx
+// Icon returns component reference (not JSX)
+figma.connect('https://...icon-url...', {
+  example: () => IconHeart  // No angle brackets
+})
+
+// Parent receives component type
+figma.connect(Button, 'https://...', {
+  props: {
+    Icon: figma.instance<React.FunctionComponent>('Icon')
+  },
+  example: ({ Icon }) => <Button Icon={Icon} />
+})
+// Renders: <Button Icon={IconHeart} />
+```
+
+### Icons as String IDs
+```tsx
+// Icon returns string ID
+figma.connect('https://...icon-url...', {
+  example: () => 'icon-heart'
+})
+
+// Parent uses string
+figma.connect(Button, 'https://...', {
+  props: {
+    iconId: figma.instance<string>('Icon')
+  },
+  example: ({ iconId }) => <Button iconId={iconId} />
+})
+// Renders: <Button iconId="icon-heart" />
+```
+
+## Output
+
+Write raw file content only—no markdown fences, no explanations.
+
+**File location:** `{ComponentFolder}/{ComponentName}.figma.tsx`
+
+Example: `src/components/inline-edit/EditableText/EditableText.figma.tsx`
+
+File must be immediately usable with `npx @figma/code-connect connect publish`.

--- a/.github/skills/figma-connect-shadcn/SKILL.md
+++ b/.github/skills/figma-connect-shadcn/SKILL.md
@@ -1,0 +1,359 @@
+---
+name: figma-connect-shadcn
+description: Connect shadcn/ui components to their Figma design system counterparts using Code Connect.
+---
+# Connect shadcn/ui Components to Figma
+
+## When to Use This Skill
+- User wants to connect shadcn/ui components to Figma
+- User just added new shadcn components via `npx shadcn@latest add <component>`
+- Running as part of CI/CD to keep Figma connections in sync
+- Periodic audit to find unconnected components
+
+## Incremental Behavior
+This skill is **incremental by default**:
+- Scans for `.figma.tsx` files next to each component
+- Only processes components that are **missing** their Code Connect file
+- Skips components that already have connections
+- Reports both "already connected" and "newly connected" in final summary
+
+To **force reconnection** of all components, user must explicitly request it.
+
+## Prerequisites
+
+### 1. FIGMA_ACCESS_TOKEN
+Ensure `.env` has a valid Figma token:
+```bash
+FIGMA_ACCESS_TOKEN=figd_...
+```
+
+Get one from: https://www.figma.com/developers/api#access-tokens
+
+### 2. Locate shadcn Configuration
+Find the `components.json` file to determine:
+- **Component output path**: Check `aliases.ui` (typically `@/components/ui`)
+- **Style variant**: `style` field (e.g., `"new-york"` or `"default"`)
+- **Icon library**: `iconLibrary` field (e.g., `"lucide"`)
+
+## Required Inputs
+1. **Figma file URL**: The Figma file containing shadcn component designs
+2. **shadcn component folder**: Auto-discovered from `components.json` → typically `src/components/ui/`
+
+## Execution Steps
+
+### Step 1: Extract Figma Components
+
+**Use the `figma-explore` skill's script** to get all components from the Figma file:
+
+```bash
+source .env && node .github/skills/figma-explore/figma-extract-all.js "<figmaUrl>" --output .temp/figma-connect-shadcn
+```
+
+This creates:
+- `.temp/figma-connect-shadcn/figma-components-index.json` - List of all Figma components
+- `.temp/figma-connect-shadcn/<component>.json` - Evidence for each component
+
+**If the script fails**, check:
+- Token expired? Regenerate at https://www.figma.com/developers/api#access-tokens
+- No access? User may need to duplicate a Community file to their account
+
+### Step 2: Discover Project Configuration
+
+Read `components.json` and write notes to `.temp/figma-connect-shadcn/shadcn-discovery.md`:
+
+```markdown
+# shadcn/ui Discovery Notes
+
+## Configuration (from components.json)
+- Style: {style}
+- UI Path: {aliases.ui}
+- Icon Library: {iconLibrary}
+- Tailwind CSS Variables: {tailwind.cssVariables}
+
+## Installed Components
+{list of .tsx files in ui folder, excluding .stories.tsx and .test.tsx}
+
+## Figma Source
+- File Key: {fileKey}
+- Components Found: {count from figma-components-index.json}
+```
+
+### Step 3: Inventory shadcn Components
+
+Scan the UI components folder:
+
+```bash
+# Expected location from components.json aliases.ui
+packages/client/src/components/ui/
+```
+
+**For each `.tsx` file**, check if a corresponding `.figma.tsx` exists:
+- `button.tsx` → check for `button.figma.tsx`
+- `card.tsx` → check for `card.figma.tsx`
+
+**Filter out non-component files:**
+- `*.stories.tsx` (Storybook)
+- `*.test.tsx` (tests)
+- `*.figma.tsx` (Code Connect files themselves)
+- `index.ts` (barrel exports)
+
+Write to `.temp/figma-connect-shadcn/shadcn-components.md`:
+
+```markdown
+# shadcn Components Inventory
+
+## Summary
+- Total components: 14
+- Already connected: 8 ✅
+- Need connection: 6 ⏳
+
+## Component Status
+| Component | File | Figma Connect | Status |
+|-----------|------|---------------|--------|
+| Button | button.tsx | button.figma.tsx | ✅ Already connected |
+| Card | card.tsx | - | ⏳ Needs connection |
+...
+```
+
+### Step 4: Match shadcn to Figma Components
+
+Read `.temp/figma-connect-shadcn/figma-components-index.json` and match shadcn component names to Figma components.
+
+**Matching strategy:**
+1. Exact name match (case-insensitive): `button.tsx` → `Button`
+2. Common aliases: `input.tsx` → `Input` or `Text Field` or `TextField`
+3. Compound components: `card.tsx` → `Card` (matches CardHeader, CardContent, etc.)
+
+Write to `.temp/figma-connect-shadcn/shadcn-figma-mapping.md`:
+
+```markdown
+# shadcn → Figma Component Mapping
+
+| shadcn Component | Figma Component | Node ID | Evidence File |
+|------------------|-----------------|---------|---------------|
+| button | Button | 16:1234 | button.json |
+| card | Card | 16:2345 | card.json |
+| select | Select & Combobox | 16:1730 | select_combobox.json |
+| skeleton | - | - | ❌ No match |
+```
+
+### Step 5: Generate Connection Tasks
+
+**Only create tasks for components that need connection** (from Step 3's inventory) and have a Figma match (from Step 4's mapping).
+
+Write to `.temp/figma-connect-shadcn/shadcn-connect-tasks.md`:
+
+```markdown
+# Code Connect Tasks
+
+## Run Info
+- Date: {timestamp}
+- Total shadcn components: 14
+- Already connected: 8 (skipped)
+- No Figma match: 1 (skipped)
+- Tasks to run: 5
+
+## Tasks to Execute
+Each task will be executed by a subagent with the figma-connect-component skill.
+
+### Task 1: Card
+- **Code Path**: packages/client/src/components/ui/card.tsx
+- **Figma Node ID**: 16:2345
+- **Figma URL**: https://figma.com/design/{fileKey}?node-id=16-2345
+- **Evidence File**: .temp/figma-connect-shadcn/card.json
+- **Output**: packages/client/src/components/ui/card.figma.tsx
+- **Status**: ⏳ Pending
+
+### Task 2: Input
+- **Code Path**: packages/client/src/components/ui/input.tsx
+- **Figma Node ID**: 16:3456
+- **Figma URL**: https://figma.com/design/{fileKey}?node-id=16-3456
+- **Evidence File**: .temp/figma-connect-shadcn/input.json
+- **Output**: packages/client/src/components/ui/input.figma.tsx
+- **Status**: ⏳ Pending
+
+...
+
+## Skipped - Already Connected
+| Component | Existing File |
+|-----------|---------------|
+| Button | button.figma.tsx |
+| Calendar | calendar.figma.tsx |
+...
+
+## Skipped - No Figma Match
+- skeleton.tsx (no corresponding Figma component found in index)
+```
+
+### Step 6: Execute Tasks via Subagents
+
+**Only process tasks with "⏳ Pending" status** from the tasks document.
+
+**Before spawning subagents:** Read the full contents of `.github/skills/figma-connect-component/SKILL.md` and store it. Subagents cannot access skill files directly, so you must inline the instructions.
+
+For each pending task, spawn a subagent with:
+1. The skill instructions (inlined)
+2. The component code path
+3. The Figma evidence file content (read from `.figma-components/{name}.json`)
+4. The output path for the `.figma.tsx` file
+
+```typescript
+// First, read the skill file (do this once before the loop)
+const skillInstructions = readFile('.github/skills/figma-connect-component/SKILL.md')
+
+// Then for each pending task:
+const evidenceFile = readFile(`.temp/figma-connect-shadcn/${componentName}.json`)
+
+runSubagent({
+  description: "Connect Card to Figma",
+  prompt: `
+    Create a Figma Code Connect file for a React component.
+    
+    ## Inputs
+    - Component Path: packages/client/src/components/ui/card.tsx
+    - Figma File Key: ${fileKey}
+    - Figma Node ID: 16:2345
+    - Output Path: packages/client/src/components/ui/card.figma.tsx
+    
+    ## Figma Component Evidence
+    \`\`\`json
+    ${JSON.stringify(evidenceFile, null, 2)}
+    \`\`\`
+    
+    ## Instructions
+    Follow these instructions to create the Code Connect file:
+    
+    ${skillInstructions}
+    
+    ## Return
+    Return the file path of the created .figma.tsx file, or an error message if failed.
+  `
+})
+```
+
+Update each task status in the document as it completes (⏳ → ✅ or ❌).
+
+### Step 7: Verify and Report
+
+After all subagents complete, update `.temp/figma-connect-shadcn/shadcn-connect-tasks.md` with final summary:
+
+```markdown
+## Run Summary
+- **Run Date**: 2026-01-16 14:30
+- **Total shadcn components**: 14
+- **Already connected (before run)**: 8
+- **Tasks attempted**: 6
+- **Successful**: 5
+- **Failed**: 1
+
+## Newly Created
+| Component | Figma Connect File | Status |
+|-----------|-------------------|--------|
+| Card | card.figma.tsx | ✅ Created |
+| Input | input.figma.tsx | ✅ Created |
+| Textarea | textarea.figma.tsx | ✅ Created |
+| Select | select.figma.tsx | ✅ Created |
+| Label | label.figma.tsx | ✅ Created |
+
+## Failed
+| Component | Error |
+|-----------|-------|
+| Tooltip | No matching Figma component found |
+
+## Previously Connected (Unchanged)
+Button, Calendar, DatePicker, ... (8 components)
+
+## Next Steps
+Run `npx @figma/code-connect publish` to push connections to Figma.
+```
+
+## shadcn-Specific Mapping Rules
+
+### Component Name Mapping
+| shadcn Export | Typical Figma Name |
+|---------------|-------------------|
+| `Button` | `Button` |
+| `Card`, `CardHeader`, `CardTitle`, `CardContent` | `Card` (compound) |
+| `Input` | `Input` / `Text Field` |
+| `Label` | `Label` |
+| `Select`, `SelectTrigger`, `SelectContent` | `Select` / `Dropdown` |
+| `Sheet`, `SheetTrigger`, `SheetContent` | `Sheet` / `Drawer` / `Side Panel` |
+| `AlertDialog` | `Alert Dialog` / `Modal` |
+| `DropdownMenu` | `Dropdown Menu` / `Menu` |
+
+### Variant Mapping (shadcn → Figma)
+```tsx
+// shadcn uses lowercase variants
+variant: figma.enum('Variant', {
+  'Default': 'default',
+  'Destructive': 'destructive',
+  'Outline': 'outline',
+  'Secondary': 'secondary',
+  'Ghost': 'ghost',
+  'Link': 'link'
+})
+
+size: figma.enum('Size', {
+  'Default': 'default',
+  'Small': 'sm',
+  'Large': 'lg',
+  'Icon': 'icon'
+})
+```
+
+### Compound Component Pattern
+shadcn uses compound components. Connect the root and document composition:
+
+```tsx
+import figma from '@figma/code-connect'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from './card'
+
+// Connect the main Card component
+figma.connect(Card, 'https://figma.com/...', {
+  props: {
+    children: figma.children('*')
+  },
+  example: ({ children }) => (
+    <Card>
+      <CardHeader>
+        <CardTitle>Title</CardTitle>
+        <CardDescription>Description</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {children}
+      </CardContent>
+      <CardFooter>
+        Footer content
+      </CardFooter>
+    </Card>
+  )
+})
+```
+
+## Output Files
+
+All work files go in `.temp/figma-connect-shadcn/`:
+- `figma-components-index.json` - Index of all Figma components
+- `<component>.json` - Detailed evidence per component (e.g., `button.json`)
+- `shadcn-discovery.md` - Configuration findings
+- `shadcn-components.md` - Component inventory
+- `shadcn-figma-mapping.md` - Figma node mappings
+- `shadcn-connect-tasks.md` - Task list and status
+
+### Final Code Connect Files
+Code Connect files go next to components:
+- `packages/client/src/components/ui/button.figma.tsx`
+- `packages/client/src/components/ui/card.figma.tsx`
+- etc.
+
+## Verification
+
+After all connections are created:
+
+```bash
+# Validate connections
+npx @figma/code-connect parse
+
+# Publish to Figma
+npx @figma/code-connect publish
+```

--- a/.github/skills/figma-explore/SKILL.md
+++ b/.github/skills/figma-explore/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: figma-explore
+description: Explore a Figma file to discover all pages, components, and component sets using the Figma REST API. Use when you need to list components in a Figma file, find component node IDs for Code Connect, or understand the structure of a design file.
+---
+
+# Skill: Explore Figma Files
+
+This skill provides scripts to explore Figma files via the REST API, bypassing the limitations of the MCP tools which require a specific node ID.
+
+## When to Use This Skill
+
+- User provides a Figma file URL without a specific node ID
+- Need to discover all components in a Figma design system
+- Want to find component node IDs for Code Connect setup
+- Need to understand the page/component structure of a Figma file
+
+## Prerequisites
+
+1. **FIGMA_ACCESS_TOKEN**: Set in `.env` or environment
+   - Get from: https://www.figma.com/developers/api#access-tokens
+   - Required scope: `file_content:read`
+
+2. **Node.js**: Version 18+ (for native fetch)
+
+## The Script: `figma-extract-all.js`
+
+A single script that handles both discovery and full extraction with batched API requests.
+
+**Usage:**
+```bash
+node .github/skills/figma-explore/figma-extract-all.js <figmaFileUrl> [options]
+```
+
+**Options:**
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--list-only` | Quick discovery only (1 API call) | Full extraction |
+| `--output <dir>` | Output directory for JSON files | `.temp/figma-explore` |
+| `--batch-size <n>` | Components per batch request | 30 |
+| `--delay <ms>` | Delay between batches (rate limiting) | 1000 |
+
+### Quick Discovery (1 API call)
+```bash
+node .github/skills/figma-explore/figma-extract-all.js <url> --list-only
+```
+Outputs JSON with component names, IDs, and URLs to stdout.
+
+### Full Extraction (batched)
+```bash
+node .github/skills/figma-explore/figma-extract-all.js <url>
+```
+Writes to `.temp/figma-explore/`:
+- `figma-components-index.json` - Summary index
+- `<component>.json` - Full evidence per component
+
+### API Call Efficiency
+
+| Mode | 45 Components | API Calls |
+|------|---------------|-----------|
+| `--list-only` | 1 call | ✅ Instant |
+| Full extraction | 1 + ⌈45/30⌉ = 3 calls | ✅ Batched |
+
+## Execution Steps
+
+### Step 1: Verify Environment
+
+Before running the script, ensure the token is available:
+
+```bash
+# Check if token is set
+source .env 2>/dev/null
+[ -n "$FIGMA_ACCESS_TOKEN" ] && echo "Token: set" || echo "Token: missing"
+```
+
+If not set:
+1. Create token at https://www.figma.com/developers/api#access-tokens
+2. Add to `.env`: `FIGMA_ACCESS_TOKEN=figd_...`
+
+### Step 2: Run Extraction
+
+**Quick discovery:**
+```bash
+source .env && node .github/skills/figma-explore/figma-extract-all.js "<figmaUrl>" --list-only
+```
+
+**Full extraction:**
+```bash
+source .env && node .github/skills/figma-explore/figma-extract-all.js "<figmaUrl>"
+```
+
+### Step 3: Use Results
+
+**Index file** (`.temp/figma-explore/figma-components-index.json`):
+```json
+{
+  "fileName": "Obra shadcn/ui",
+  "fileKey": "MQUbIrlfuM8qnr9XZ7jc82",
+  "totalComponents": 45,
+  "components": [
+    { "name": "Button", "id": "16:1234", "url": "..." }
+  ]
+}
+```
+
+**Component evidence** (`.temp/figma-explore/button.json`):
+```json
+{
+  "componentSetId": "16:1234",
+  "componentName": "Button",
+  "variantProperties": { "Size": ["Small", "Large"] },
+  "componentProperties": [{ "name": "Disabled", "type": "BOOLEAN" }],
+  "textLayers": [{ "name": "Label", "characters": "Button" }],
+  "slotLayers": [{ "name": "Icon", "type": "INSTANCE" }]
+}
+```
+
+### Step 4: Generate Code Connect
+
+Use the evidence files with:
+- The `figma-connect-component` skill
+- Direct Code Connect generation
+- Manual `.figma.tsx` file creation
+
+## Figma REST API Reference
+
+The scripts use these endpoints:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /v1/files/:file_key` | Get entire file structure |
+| `GET /v1/files/:file_key/nodes?ids=:node_ids` | Get specific node details |
+| `GET /v1/files/:file_key/components` | List published components |
+
+## Troubleshooting
+
+### 401/403 Errors
+- Token is invalid or expired
+- Token doesn't have `file_content:read` scope
+- Regenerate at https://www.figma.com/developers/api#access-tokens
+
+### 404 Errors  
+- File key is incorrect
+- You don't have access to the file
+- File has been deleted or moved
+
+### Network Errors
+- Check internet connection
+- Corporate proxy may need HTTP_PROXY/HTTPS_PROXY set

--- a/.github/skills/figma-explore/figma-extract-all.js
+++ b/.github/skills/figma-explore/figma-extract-all.js
@@ -1,0 +1,534 @@
+#!/usr/bin/env node
+
+/**
+ * Figma Full Component Extractor
+ * 
+ * Extracts all components from a Figma file with full details in batched requests.
+ * Combines listing + detail fetching into one efficient operation.
+ * 
+ * Usage:
+ *   node figma-extract-all.js <figmaFileUrl> [options]
+ * 
+ * Options:
+ *   --list-only        List components only (1 API call, no details)
+ *   --output <dir>     Output directory for JSON files (default: .figma-components)
+ *   --batch-size <n>   Number of components per batch request (default: 30)
+ *   --delay <ms>       Delay between batch requests in ms (default: 1000)
+ * 
+ * Environment:
+ *   FIGMA_ACCESS_TOKEN - Figma personal access token (required)
+ * 
+ * Output:
+ *   - figma-components-index.json  - Summary of all components
+ *   - <component-name>.json        - Detailed evidence for each component
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Load .env from project root
+const envPath = path.resolve(process.cwd(), '.env');
+if (fs.existsSync(envPath)) {
+  const envContent = fs.readFileSync(envPath, 'utf8');
+  for (const line of envContent.split('\n')) {
+    const match = line.match(/^([^=]+)=(.*)$/);
+    if (match && !process.env[match[1]]) {
+      process.env[match[1]] = match[2].replace(/^["']|["']$/g, '');
+    }
+  }
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const DEFAULT_BATCH_SIZE = 30;  // Figma recommends keeping batches reasonable
+const DEFAULT_DELAY_MS = 1000;  // 1 second between batches to avoid rate limits
+const DEFAULT_OUTPUT_DIR = '.temp/figma-explore';
+
+// Modes
+const MODE_FULL = 'full';      // List + fetch details
+const MODE_LIST = 'list';      // List only (1 API call)
+
+// ============================================================================
+// Utilities
+// ============================================================================
+
+function parseFileKey(input) {
+  if (!input) return null;
+  if (!input.includes('/')) return input;
+  
+  const designMatch = input.match(/figma\.com\/design\/([^\/]+)/);
+  if (designMatch) return designMatch[1];
+  
+  const fileMatch = input.match(/figma\.com\/file\/([^\/]+)/);
+  if (fileMatch) return fileMatch[1];
+  
+  return null;
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const config = {
+    fileUrl: null,
+    fileKey: null,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    batchSize: DEFAULT_BATCH_SIZE,
+    delayMs: DEFAULT_DELAY_MS,
+    mode: MODE_FULL
+  };
+  
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--output' && args[i + 1]) {
+      config.outputDir = args[++i];
+    } else if (arg === '--batch-size' && args[i + 1]) {
+      config.batchSize = parseInt(args[++i], 10);
+    } else if (arg === '--delay' && args[i + 1]) {
+      config.delayMs = parseInt(args[++i], 10);
+    } else if (arg === '--list-only' || arg === '--list') {
+      config.mode = MODE_LIST;
+    } else if (!arg.startsWith('--')) {
+      config.fileUrl = arg;
+      config.fileKey = parseFileKey(arg);
+    }
+  }
+  
+  return config;
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function normalizeComponentName(name) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .replace(/_+/g, '_');
+}
+
+// ============================================================================
+// Figma API
+// ============================================================================
+
+async function figmaRequest(pathname, token) {
+  const response = await fetch(`https://api.figma.com${pathname}`, {
+    method: 'GET',
+    headers: { 'X-Figma-Token': token }
+  });
+  
+  if (!response.ok) {
+    const text = await response.text();
+    
+    // Check for rate limiting
+    if (response.status === 429) {
+      const retryAfter = response.headers.get('Retry-After') || '60';
+      throw new Error(`Rate limited. Retry after ${retryAfter} seconds.`);
+    }
+    
+    if (response.status === 401 || response.status === 403) {
+      throw new Error(
+        `Authentication failed (${response.status})\n` +
+        `Verify FIGMA_ACCESS_TOKEN is set correctly.`
+      );
+    }
+    if (response.status === 404) {
+      throw new Error(`File not found (404)`);
+    }
+    throw new Error(`Figma API error: ${response.status} - ${text}`);
+  }
+  
+  return response.json();
+}
+
+/**
+ * Fetch multiple nodes in a single batched request
+ */
+async function fetchNodesBatch(fileKey, nodeIds, token) {
+  const idsParam = nodeIds.map(id => encodeURIComponent(id)).join(',');
+  const data = await figmaRequest(`/v1/files/${fileKey}/nodes?ids=${idsParam}`, token);
+  return data.nodes || {};
+}
+
+// ============================================================================
+// Component Discovery (from file structure)
+// ============================================================================
+
+function findComponentSets(node, breadcrumbs = [], results = []) {
+  if (!node) return results;
+  
+  const currentPath = [...breadcrumbs];
+  if (node.name && node.type !== 'DOCUMENT') {
+    currentPath.push(node.name);
+  }
+  
+  // Skip hidden components
+  if (node.name && (node.name.startsWith('_') || node.name.startsWith('.'))) {
+    return results;
+  }
+  
+  if (node.type === 'COMPONENT_SET') {
+    results.push({
+      name: node.name,
+      id: node.id,
+      variantCount: node.children ? node.children.length : 0,
+      description: node.description || '',
+      path: currentPath.join(' / ')
+    });
+  }
+  
+  if (node.children) {
+    for (const child of node.children) {
+      findComponentSets(child, currentPath, results);
+    }
+  }
+  
+  return results;
+}
+
+// ============================================================================
+// Component Detail Extraction
+// ============================================================================
+
+function extractVariantProperties(componentSet) {
+  const variantProps = {};
+  
+  if (!componentSet.children) return variantProps;
+  
+  for (const variant of componentSet.children) {
+    if (variant.type !== 'COMPONENT') continue;
+    
+    const parts = variant.name.split(',').map(p => p.trim());
+    for (const part of parts) {
+      const [key, value] = part.split('=').map(s => s.trim());
+      if (key && value) {
+        if (!variantProps[key]) {
+          variantProps[key] = new Set();
+        }
+        variantProps[key].add(value);
+      }
+    }
+  }
+  
+  // Convert sets to arrays and create enum mappings
+  const result = {};
+  const enumMappings = {};
+  
+  for (const [key, values] of Object.entries(variantProps)) {
+    const valuesArray = Array.from(values);
+    result[key] = valuesArray;
+    
+    // Create normalized enum values for code
+    enumMappings[key] = {
+      rawKey: key,
+      normalizedKey: key.charAt(0).toLowerCase() + key.slice(1),
+      values: valuesArray,
+      enums: valuesArray.map(v => v.toLowerCase().replace(/\s+/g, '-'))
+    };
+  }
+  
+  return { variantProperties: result, variantValueEnums: enumMappings };
+}
+
+function extractComponentProperties(componentSet) {
+  const props = [];
+  
+  if (!componentSet.componentPropertyDefinitions) return props;
+  
+  for (const [name, def] of Object.entries(componentSet.componentPropertyDefinitions)) {
+    const cleanName = name.replace(/#\d+:\d+$/, '');
+    props.push({
+      name: cleanName,
+      type: def.type,
+      defaultValue: def.defaultValue,
+      variantOptions: def.variantOptions
+    });
+  }
+  
+  return props;
+}
+
+function findTextLayers(node, depth = 0, maxDepth = 5, results = []) {
+  if (!node || depth > maxDepth) return results;
+  
+  if (node.type === 'TEXT') {
+    results.push({
+      name: node.name,
+      type: 'TEXT',
+      characters: node.characters || ''
+    });
+  }
+  
+  if (node.children) {
+    for (const child of node.children) {
+      findTextLayers(child, depth + 1, maxDepth, results);
+    }
+  }
+  
+  return results;
+}
+
+function findSlotLayers(node, depth = 0, maxDepth = 5, results = []) {
+  if (!node || depth > maxDepth) return results;
+  
+  if (node.type === 'FRAME' || node.type === 'INSTANCE') {
+    const name = (node.name || '').toLowerCase();
+    if (name.includes('slot') || 
+        name.includes('content') ||
+        name.includes('icon') ||
+        name.includes('leading') ||
+        name.includes('trailing') ||
+        name.includes('children')) {
+      results.push({
+        name: node.name,
+        type: node.type
+      });
+    }
+  }
+  
+  if (node.children) {
+    for (const child of node.children) {
+      findSlotLayers(child, depth + 1, maxDepth, results);
+    }
+  }
+  
+  return results;
+}
+
+function extractComponentEvidence(nodeId, document, fileKey) {
+  const { variantProperties, variantValueEnums } = extractVariantProperties(document);
+  
+  const evidence = {
+    schemaVersion: 'figma-component@1',
+    componentSetId: nodeId,
+    componentName: document.name,
+    description: document.description || '',
+    url: `https://www.figma.com/design/${fileKey}?node-id=${nodeId.replace(':', '-')}`,
+    variantProperties,
+    variantValueEnums,
+    componentProperties: extractComponentProperties(document),
+    textLayers: [],
+    slotLayers: [],
+    variants: [],
+    totalVariants: 0
+  };
+  
+  if (document.children) {
+    evidence.totalVariants = document.children.filter(c => c.type === 'COMPONENT').length;
+    
+    // Extract from first variant for text/slot layers
+    const firstVariant = document.children.find(c => c.type === 'COMPONENT');
+    if (firstVariant) {
+      evidence.textLayers = findTextLayers(firstVariant);
+      evidence.slotLayers = findSlotLayers(firstVariant);
+    }
+    
+    // List all variants
+    evidence.variants = document.children
+      .filter(c => c.type === 'COMPONENT')
+      .map(c => ({
+        name: c.name,
+        id: c.id
+      }));
+  }
+  
+  return evidence;
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+async function main() {
+  const config = parseArgs();
+  
+  if (!config.fileKey) {
+    console.error('Usage: node figma-extract-all.js <figmaFileUrl> [options]');
+    console.error('');
+    console.error('Options:');
+    console.error('  --list-only        List components only (1 API call, no details)');
+    console.error('  --output <dir>     Output directory (default: .figma-components)');
+    console.error('  --batch-size <n>   Components per batch request (default: 30)');
+    console.error('  --delay <ms>       Delay between batches in ms (default: 1000)');
+    process.exit(1);
+  }
+  
+  const token = process.env.FIGMA_ACCESS_TOKEN;
+  if (!token) {
+    console.error('Error: FIGMA_ACCESS_TOKEN environment variable is required');
+    process.exit(1);
+  }
+  
+  try {
+    // ========================================================================
+    // Step 1: Fetch file structure
+    // ========================================================================
+    console.error(`\n📁 Fetching Figma file: ${config.fileKey}`);
+    
+    const fileData = await figmaRequest(`/v1/files/${config.fileKey}`, token);
+    
+    console.error(`   File: ${fileData.name}`);
+    console.error(`   Version: ${fileData.version}`);
+    console.error(`   Last Modified: ${fileData.lastModified}`);
+    
+    // ========================================================================
+    // Step 2: Discover all component sets
+    // ========================================================================
+    const pages = fileData.document.children || [];
+    console.error(`\n📑 Pages: ${pages.map(p => p.name).join(', ')}`);
+    
+    const allComponents = [];
+    for (const page of pages) {
+      const components = findComponentSets(page);
+      for (const comp of components) {
+        comp.page = page.name;
+        allComponents.push(comp);
+      }
+    }
+    
+    console.error(`\n🧩 Found ${allComponents.length} component sets`);
+    
+    if (allComponents.length === 0) {
+      console.error('   No components found in file.');
+      process.exit(0);
+    }
+    
+    // ========================================================================
+    // List-only mode: output summary and exit
+    // ========================================================================
+    if (config.mode === MODE_LIST) {
+      const listResult = {
+        fileName: fileData.name,
+        fileKey: config.fileKey,
+        fileUrl: `https://www.figma.com/design/${config.fileKey}`,
+        version: fileData.version,
+        lastModified: fileData.lastModified,
+        totalComponents: allComponents.length,
+        components: allComponents.map(c => ({
+          name: c.name,
+          id: c.id,
+          page: c.page,
+          path: c.path,
+          variantCount: c.variantCount,
+          url: `https://www.figma.com/design/${config.fileKey}?node-id=${c.id.replace(':', '-')}`
+        }))
+      };
+      
+      console.error(`\n✅ List complete! (use without --list-only for full extraction)`);
+      console.log(JSON.stringify(listResult, null, 2));
+      process.exit(0);
+    }
+    
+    // ========================================================================
+    // Step 3: Batch fetch component details
+    // ========================================================================
+    const nodeIds = allComponents.map(c => c.id);
+    const batches = [];
+    
+    for (let i = 0; i < nodeIds.length; i += config.batchSize) {
+      batches.push(nodeIds.slice(i, i + config.batchSize));
+    }
+    
+    console.error(`\n📦 Fetching details in ${batches.length} batch(es) of up to ${config.batchSize}...`);
+    
+    const allNodeData = {};
+    
+    for (let i = 0; i < batches.length; i++) {
+      const batch = batches[i];
+      console.error(`   Batch ${i + 1}/${batches.length}: ${batch.length} components...`);
+      
+      const batchResults = await fetchNodesBatch(config.fileKey, batch, token);
+      Object.assign(allNodeData, batchResults);
+      
+      // Delay between batches (except for last batch)
+      if (i < batches.length - 1) {
+        await sleep(config.delayMs);
+      }
+    }
+    
+    // ========================================================================
+    // Step 4: Extract evidence and write output
+    // ========================================================================
+    console.error(`\n💾 Writing output to ${config.outputDir}/`);
+    
+    // Ensure output directory exists
+    if (!fs.existsSync(config.outputDir)) {
+      fs.mkdirSync(config.outputDir, { recursive: true });
+    }
+    
+    const componentIndex = [];
+    const usedFilenames = new Set();
+    
+    for (const component of allComponents) {
+      const nodeData = allNodeData[component.id];
+      if (!nodeData || !nodeData.document) {
+        console.error(`   ⚠️  Skipping ${component.name}: no data returned`);
+        continue;
+      }
+      
+      const evidence = extractComponentEvidence(
+        component.id,
+        nodeData.document,
+        config.fileKey
+      );
+      
+      // Generate unique filename
+      let filename = normalizeComponentName(component.name);
+      let counter = 1;
+      while (usedFilenames.has(filename)) {
+        filename = `${normalizeComponentName(component.name)}_${counter++}`;
+      }
+      usedFilenames.add(filename);
+      
+      // Write individual component file
+      const componentPath = path.join(config.outputDir, `${filename}.json`);
+      fs.writeFileSync(componentPath, JSON.stringify(evidence, null, 2));
+      
+      // Add to index
+      componentIndex.push({
+        name: component.name,
+        id: component.id,
+        filename: `${filename}.json`,
+        page: component.page,
+        path: component.path,
+        variantCount: evidence.totalVariants,
+        url: evidence.url
+      });
+    }
+    
+    // Write index file
+    const indexData = {
+      schemaVersion: 'figma-component-index@1',
+      fileName: fileData.name,
+      fileKey: config.fileKey,
+      fileUrl: `https://www.figma.com/design/${config.fileKey}`,
+      version: fileData.version,
+      lastModified: fileData.lastModified,
+      exportDate: new Date().toISOString(),
+      totalComponents: componentIndex.length,
+      components: componentIndex
+    };
+    
+    const indexPath = path.join(config.outputDir, 'figma-components-index.json');
+    fs.writeFileSync(indexPath, JSON.stringify(indexData, null, 2));
+    
+    // ========================================================================
+    // Summary
+    // ========================================================================
+    console.error(`\n✅ Complete!`);
+    console.error(`   Components extracted: ${componentIndex.length}`);
+    console.error(`   Index file: ${indexPath}`);
+    console.error(`   Component files: ${config.outputDir}/*.json`);
+    
+    // Output index to stdout for piping
+    console.log(JSON.stringify(indexData, null, 2));
+    
+  } catch (error) {
+    console.error(`\n❌ Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/client/figma.config.json
+++ b/packages/client/figma.config.json
@@ -1,0 +1,10 @@
+{
+  "codeConnect": {
+    "parser": "react",
+    "include": ["src/components/**/*.tsx"],
+    "exclude": ["**/*.test.tsx", "**/*.stories.tsx"],
+    "importPaths": {
+      "src/components/*": "@/components/*"
+    }
+  }
+}

--- a/packages/client/src/components/inline-edit/EditableText/EditableText.figma.tsx
+++ b/packages/client/src/components/inline-edit/EditableText/EditableText.figma.tsx
@@ -1,0 +1,22 @@
+import figma from '@figma/code-connect';
+import { EditableText } from './EditableText';
+
+figma.connect(
+  EditableText,
+  'https://www.figma.com/design/7QW0kJ07DcM36mgQUJ5Dtj/Carton-Case-Management?node-id=1261-9396',
+  {
+    props: {
+      label: figma.textContent('Label'),
+      value: figma.textContent('Content area'),
+    },
+    example: ({ label, value }) => (
+      <EditableText
+        label={label}
+        value={value}
+        onSave={async (newValue) => {
+          // Save handler
+        }}
+      />
+    ),
+  }
+);

--- a/packages/client/src/components/ui/alert-dialog.figma.tsx
+++ b/packages/client/src/components/ui/alert-dialog.figma.tsx
@@ -1,0 +1,37 @@
+import figma from '@figma/code-connect'
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogAction,
+  AlertDialogCancel
+} from './alert-dialog'
+import { Button } from './button'
+
+figma.connect(AlertDialogContent, 'https://figma.com/design/MQUbIrlfuM8qnr9XZ7jc82?node-id=139-11941', {
+  props: {
+    title: figma.textContent('Title'),
+    description: figma.textContent('Text')
+  },
+  example: ({ title, description }) => (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="outline">Open</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction>Continue</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+})

--- a/packages/client/src/components/ui/button.figma.tsx
+++ b/packages/client/src/components/ui/button.figma.tsx
@@ -1,0 +1,30 @@
+import figma from '@figma/code-connect'
+import { Button } from './button'
+
+figma.connect(Button, 'https://figma.com/design/MQUbIrlfuM8qnr9XZ7jc82?node-id=9-1071', {
+  props: {
+    variant: figma.enum('Variant', {
+      'Primary': 'default',
+      'Secondary': 'secondary',
+      'Outline': 'outline',
+      'Ghost': 'ghost',
+      'Ghost Muted': 'ghost',
+      'Destructive': 'destructive'
+    }),
+    size: figma.enum('Size', {
+      'Regular': 'default',
+      'Large': 'lg',
+      'Small': 'sm',
+      'Mini': 'sm'
+    }),
+    disabled: figma.enum('State', {
+      'Disabled': true
+    }),
+    children: figma.textContent('Label')
+  },
+  example: ({ variant, size, disabled, children }) => (
+    <Button variant={variant} size={size} disabled={disabled}>
+      {children}
+    </Button>
+  )
+})

--- a/packages/client/src/components/ui/calendar.figma.tsx
+++ b/packages/client/src/components/ui/calendar.figma.tsx
@@ -1,0 +1,18 @@
+import figma from '@figma/code-connect'
+import { Calendar } from './calendar'
+
+figma.connect(Calendar, 'https://figma.com/design/MQUbIrlfuM8qnr9XZ7jc82?node-id=288-119954', {
+  props: {
+    numberOfMonths: figma.enum('Months', {
+      '1 Month': 1,
+      '2 months': 2,
+      '3 months': 3
+    })
+  },
+  example: ({ numberOfMonths }) => (
+    <Calendar
+      mode="single"
+      numberOfMonths={numberOfMonths}
+    />
+  )
+})

--- a/packages/client/src/components/ui/card.figma.tsx
+++ b/packages/client/src/components/ui/card.figma.tsx
@@ -1,0 +1,22 @@
+import figma from '@figma/code-connect'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from './card'
+
+figma.connect(Card, 'https://figma.com/design/MQUbIrlfuM8qnr9XZ7jc82?node-id=179-29234', {
+  props: {
+    children: figma.children('*')
+  },
+  example: ({ children }) => (
+    <Card>
+      <CardHeader>
+        <CardTitle>Title</CardTitle>
+        <CardDescription>Description</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {children}
+      </CardContent>
+      <CardFooter>
+        Footer content
+      </CardFooter>
+    </Card>
+  )
+})

--- a/packages/client/src/components/ui/date-picker.figma.tsx
+++ b/packages/client/src/components/ui/date-picker.figma.tsx
@@ -1,0 +1,11 @@
+import figma from '@figma/code-connect'
+import { DatePicker } from './date-picker'
+
+figma.connect(DatePicker, 'https://figma.com/design/MQUbIrlfuM8qnr9XZ7jc82?node-id=288-119954', {
+  example: () => (
+    <DatePicker
+      placeholder="Select date"
+      onChange={(date) => console.log(date)}
+    />
+  )
+})

--- a/packages/client/src/components/ui/dropdown-menu.figma.tsx
+++ b/packages/client/src/components/ui/dropdown-menu.figma.tsx
@@ -1,0 +1,26 @@
+import figma from '@figma/code-connect'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem
+} from './dropdown-menu'
+import { Button } from './button'
+
+figma.connect(DropdownMenuContent, 'https://figma.com/design/MQUbIrlfuM8qnr9XZ7jc82?node-id=176-27848', {
+  props: {
+    children: figma.children('*')
+  },
+  example: ({ children }) => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">Open menu</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem>Item 1</DropdownMenuItem>
+        <DropdownMenuItem>Item 2</DropdownMenuItem>
+        <DropdownMenuItem>Item 3</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+})

--- a/packages/client/src/components/ui/input.figma.tsx
+++ b/packages/client/src/components/ui/input.figma.tsx
@@ -1,0 +1,13 @@
+import figma from '@figma/code-connect'
+import { Input } from './input'
+
+figma.connect(Input, 'https://figma.com/design/MQUbIrlfuM8qnr9XZ7jc82?node-id=16-1738', {
+  props: {
+    disabled: figma.enum('State', {
+      'Disabled': true
+    })
+  },
+  example: ({ disabled }) => (
+    <Input placeholder="Enter text..." disabled={disabled} />
+  )
+})

--- a/packages/client/src/components/ui/label.figma.tsx
+++ b/packages/client/src/components/ui/label.figma.tsx
@@ -1,0 +1,11 @@
+import figma from '@figma/code-connect'
+import { Label } from './label'
+
+figma.connect(Label, 'https://figma.com/design/MQUbIrlfuM8qnr9XZ7jc82?node-id=103-9453', {
+  props: {
+    children: figma.textContent('Label')
+  },
+  example: ({ children }) => (
+    <Label>{children}</Label>
+  )
+})

--- a/packages/client/src/components/ui/select.figma.tsx
+++ b/packages/client/src/components/ui/select.figma.tsx
@@ -1,0 +1,29 @@
+import figma from '@figma/code-connect'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem
+} from './select'
+
+figma.connect(SelectTrigger, 'https://figma.com/design/MQUbIrlfuM8qnr9XZ7jc82?node-id=16-1732', {
+  props: {
+    placeholder: figma.textContent('Select an item'),
+    disabled: figma.enum('State', {
+      'Disabled': true
+    })
+  },
+  example: ({ placeholder, disabled }) => (
+    <Select disabled={disabled}>
+      <SelectTrigger>
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="option1">Option 1</SelectItem>
+        <SelectItem value="option2">Option 2</SelectItem>
+        <SelectItem value="option3">Option 3</SelectItem>
+      </SelectContent>
+    </Select>
+  )
+})

--- a/packages/client/src/components/ui/sheet.figma.tsx
+++ b/packages/client/src/components/ui/sheet.figma.tsx
@@ -1,0 +1,13 @@
+import figma from '@figma/code-connect'
+import { Sheet } from './sheet'
+
+figma.connect(Sheet, 'https://figma.com/design/MQUbIrlfuM8qnr9XZ7jc82?node-id=301-243831', {
+  props: {
+    children: figma.children('*')
+  },
+  example: ({ children }) => (
+    <Sheet open={true} onOpenChange={() => {}}>
+      {children}
+    </Sheet>
+  )
+})

--- a/packages/client/src/components/ui/textarea.figma.tsx
+++ b/packages/client/src/components/ui/textarea.figma.tsx
@@ -1,0 +1,13 @@
+import figma from '@figma/code-connect'
+import { Textarea } from './textarea'
+
+figma.connect(Textarea, 'https://figma.com/design/MQUbIrlfuM8qnr9XZ7jc82?node-id=16-1745', {
+  props: {
+    disabled: figma.enum('State', {
+      'Disabled': true
+    })
+  },
+  example: ({ disabled }) => (
+    <Textarea placeholder="Enter text..." disabled={disabled} />
+  )
+})

--- a/packages/client/src/components/ui/tooltip.figma.tsx
+++ b/packages/client/src/components/ui/tooltip.figma.tsx
@@ -1,0 +1,32 @@
+import figma from '@figma/code-connect'
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider
+} from './tooltip'
+import { Button } from './button'
+
+figma.connect(TooltipContent, 'https://figma.com/design/MQUbIrlfuM8qnr9XZ7jc82?node-id=133-14788', {
+  props: {
+    side: figma.enum('Side', {
+      'Top': 'top',
+      'Bottom': 'bottom',
+      'Left': 'left',
+      'Right': 'right'
+    }),
+    content: figma.textContent('Tooltip text')
+  },
+  example: ({ side, content }) => (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="outline">Hover me</Button>
+        </TooltipTrigger>
+        <TooltipContent side={side}>
+          <p>{content}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+})


### PR DESCRIPTION
This pull request introduces comprehensive documentation and configuration to support connecting React components—especially shadcn/ui components—to their Figma design system counterparts using Figma Code Connect. It also adds a sample Code Connect file for the `EditableText` component and a configuration file for Code Connect parsing. The main themes are skill documentation, automation workflow, and configuration setup.

**Key changes:**

**1. Figma Code Connect Skill Documentation and Workflow**
- Added `.github/skills/figma-connect-component/SKILL.md`: Detailed step-by-step instructions for generating Code Connect mapping files for React components based on Figma evidence, including strict rules for property name matching, mapping conventions, and usage of helper APIs.
- Added `.github/skills/figma-connect-shadcn/SKILL.md`: Provides a full workflow for incrementally connecting shadcn/ui components to Figma, including component discovery, evidence extraction, mapping, task generation, subagent execution, and reporting. Includes shadcn-specific mapping rules and compound component patterns.
- Added `.github/skills/figma-explore/SKILL.md`: Documents how to use scripts to extract all components and metadata from a Figma file using the REST API, supporting the above workflows.

**2. Configuration and Example Code Connect File**
- Added `packages/client/figma.config.json`: Configures Code Connect parsing for the project, specifying file inclusion/exclusion patterns and import path aliases.
- Added `packages/client/src/components/inline-edit/EditableText/EditableText.figma.tsx`: Example Code Connect file mapping the `EditableText` component’s label and content to Figma properties, demonstrating the output of the documented workflow.