### PR TITLE
Obra Alert components

### DIFF
--- a/packages/client/src/components/obra/Alert/Alert.figma.tsx
+++ b/packages/client/src/components/obra/Alert/Alert.figma.tsx
@@ -1,0 +1,42 @@
+import figma from '@figma/code-connect';
+import { Alert } from './Alert';
+
+figma.connect(Alert, 'https://www.figma.com/design/MQUbIrlfuM8qnr9XZ7jc82/Obra-shadcn-ui--Carton-?node-id=58-5416', {
+  props: {
+    type: figma.enum('Type', {
+      Neutral: 'Neutral',
+      Error: 'Error',
+    }),
+    children: figma.textContent('Line 1'),
+    description: figma.boolean('Show Line 2', {
+      true: figma.textContent('Line 2'),
+      false: undefined,
+    }),
+    showLine2: figma.boolean('Show Line 2'),
+    icon: figma.boolean('Show Icon', {
+      true: figma.instance('Icon'),
+      false: undefined,
+    }),
+    showIcon: figma.boolean('Show Icon'),
+    flipIcon: figma.boolean('Flip Icon'),
+    action: figma.boolean('Show Button', {
+      true: figma.instance('Button'),
+      false: undefined,
+    }),
+    showButton: figma.boolean('Show Button'),
+  },
+  example: ({ type, children, description, showLine2, icon, showIcon, flipIcon, action, showButton }) => (
+    <Alert
+      type={type}
+      description={description}
+      showLine2={showLine2}
+      icon={icon}
+      showIcon={showIcon}
+      flipIcon={flipIcon}
+      action={action}
+      showButton={showButton}
+    >
+      {children}
+    </Alert>
+  ),
+});

--- a/packages/client/src/components/obra/Alert/Alert.stories.tsx
+++ b/packages/client/src/components/obra/Alert/Alert.stories.tsx
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Info, AlertCircle } from 'lucide-react';
+import { Alert } from './Alert';
+
+const meta: Meta<typeof Alert> = {
+  component: Alert,
+  title: 'Obra/Alert',
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/MQUbIrlfuM8qnr9XZ7jc82/Obra-shadcn-ui--Carton-?node-id=58-5416&t=I5A0QLIu4RNqO53t-4',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Alert>;
+
+export const Default: Story = {
+  args: {
+    children: 'Line 1',
+  },
+};
+
+export const NeutralWithIcon: Story = {
+  args: {
+    children: 'Line 1',
+    icon: <Info className="h-4 w-4" />,
+    showIcon: true,
+  },
+};
+
+export const NeutralWithIconAndDescription: Story = {
+  args: {
+    children: 'Line 1',
+    description: 'Line 2',
+    showLine2: true,
+    icon: <Info className="h-4 w-4" />,
+    showIcon: true,
+  },
+};
+
+export const NeutralFlippedIcon: Story = {
+  args: {
+    children: 'Line 1',
+    icon: <Info className="h-4 w-4" />,
+    showIcon: true,
+    flipIcon: true,
+  },
+};
+
+export const NeutralWithButton: Story = {
+  args: {
+    children: 'Line 1',
+    icon: <Info className="h-4 w-4" />,
+    showIcon: true,
+    action: (
+      <button className="rounded-lg border border-border bg-background px-4 py-2 text-sm font-semibold shadow-sm hover:bg-accent">
+        Label
+      </button>
+    ),
+    showButton: true,
+  },
+};
+
+export const Error: Story = {
+  args: {
+    type: 'Error',
+    children: 'Line 1',
+  },
+};
+
+export const ErrorWithIcon: Story = {
+  args: {
+    type: 'Error',
+    children: 'Line 1',
+    icon: <AlertCircle className="h-4 w-4" />,
+    showIcon: true,
+    flipIcon: true,
+  },
+};
+
+export const ErrorWithIconAndDescription: Story = {
+  args: {
+    type: 'Error',
+    children: 'Line 1',
+    description: 'Line 2',
+    showLine2: true,
+    icon: <AlertCircle className="h-4 w-4" />,
+    showIcon: true,
+    flipIcon: true,
+  },
+};
+
+export const ErrorFlippedIcon: Story = {
+  args: {
+    type: 'Error',
+    children: 'Line 1',
+    icon: <AlertCircle className="h-4 w-4" />,
+    showIcon: true,
+    flipIcon: false,
+  },
+};
+
+export const ErrorWithButton: Story = {
+  args: {
+    type: 'Error',
+    children: 'Line 1',
+    icon: <AlertCircle className="h-4 w-4" />,
+    showIcon: true,
+    flipIcon: true,
+    action: (
+      <button className="rounded-lg border border-border bg-background px-4 py-2 text-sm font-semibold shadow-sm hover:bg-accent">
+        Label
+      </button>
+    ),
+    showButton: true,
+  },
+};
+
+export const Complete: Story = {
+  args: {
+    children: 'Line 1',
+    description: 'Line 2',
+    showLine2: true,
+    icon: <Info className="h-4 w-4" />,
+    showIcon: true,
+    action: (
+      <button className="rounded-lg border border-border bg-background px-4 py-2 text-sm font-semibold shadow-sm hover:bg-accent">
+        Label
+      </button>
+    ),
+    showButton: true,
+  },
+};

--- a/packages/client/src/components/obra/Alert/Alert.test.tsx
+++ b/packages/client/src/components/obra/Alert/Alert.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Alert } from './Alert';
+
+describe('Alert', () => {
+  it('should render with children only', () => {
+    render(<Alert>Line 1</Alert>);
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent('Line 1');
+  });
+
+  it('should render with children and description when showLine2 is true', () => {
+    render(<Alert description="Line 2" showLine2>Line 1</Alert>);
+    expect(screen.getByText('Line 1')).toBeInTheDocument();
+    expect(screen.getByText('Line 2')).toBeInTheDocument();
+  });
+
+  it('should render Neutral type (default)', () => {
+    render(<Alert>Test</Alert>);
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+  });
+
+  it('should render Error type', () => {
+    render(<Alert type="Error">Error message</Alert>);
+    const alert = screen.getByRole('alert');
+    expect(alert).toBeInTheDocument();
+  });
+
+  it('should render with icon at start position (flipIcon=false)', () => {
+    render(
+      <Alert 
+        icon={<span data-testid="test-icon">icon</span>}
+        showIcon
+        flipIcon={false}
+      >
+        Test
+      </Alert>
+    );
+    expect(screen.getByTestId('test-icon')).toBeInTheDocument();
+  });
+
+  it('should render with icon at end position (flipIcon=true)', () => {
+    render(
+      <Alert 
+        icon={<span data-testid="test-icon">icon</span>}
+        showIcon
+        flipIcon
+      >
+        Test
+      </Alert>
+    );
+    expect(screen.getByTestId('test-icon')).toBeInTheDocument();
+  });
+
+  it('should render with action button when showButton is true', () => {
+    render(
+      <Alert 
+        action={<button data-testid="action-button">Action</button>}
+        showButton
+      >
+        Test
+      </Alert>
+    );
+    expect(screen.getByTestId('action-button')).toBeInTheDocument();
+  });
+
+  it('should render all props together', () => {
+    render(
+      <Alert
+        type="Error"
+        description="Line 2"
+        showLine2
+        icon={<span data-testid="test-icon">icon</span>}
+        showIcon
+        flipIcon
+        action={<button data-testid="action-button">Action</button>}
+        showButton
+      >
+        Line 1
+      </Alert>
+    );
+    expect(screen.getByText('Line 1')).toBeInTheDocument();
+    expect(screen.getByText('Line 2')).toBeInTheDocument();
+    expect(screen.getByTestId('test-icon')).toBeInTheDocument();
+    expect(screen.getByTestId('action-button')).toBeInTheDocument();
+  });
+
+  it('should apply custom className', () => {
+    render(<Alert className="custom-class">Test</Alert>);
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveClass('custom-class');
+  });
+
+  it('should not render description when showLine2 is false', () => {
+    render(<Alert description="Line 2" showLine2={false}>Only title</Alert>);
+    expect(screen.queryByText('Line 2')).not.toBeInTheDocument();
+  });
+
+  it('should not render icon when showIcon is false', () => {
+    const { container } = render(
+      <Alert icon={<span data-testid="test-icon">icon</span>} showIcon={false}>
+        Test
+      </Alert>
+    );
+    const iconContainer = container.querySelector('[data-testid="test-icon"]');
+    expect(iconContainer).not.toBeInTheDocument();
+  });
+
+  it('should not render action when showButton is false', () => {
+    const { container } = render(
+      <Alert action={<button data-testid="action-button">Action</button>} showButton={false}>
+        Test
+      </Alert>
+    );
+    const actionButton = container.querySelector('[data-testid="action-button"]');
+    expect(actionButton).not.toBeInTheDocument();
+  });
+});

--- a/packages/client/src/components/obra/Alert/Alert.tsx
+++ b/packages/client/src/components/obra/Alert/Alert.tsx
@@ -1,0 +1,79 @@
+import { cn } from '@/lib/utils';
+import type { AlertProps } from './types';
+
+export function Alert({ 
+  type = 'Neutral',
+  children,
+  description,
+  showLine2,
+  icon,
+  showIcon,
+  flipIcon = false,
+  action,
+  showButton,
+  className,
+}: AlertProps) {
+  const typeStyles = {
+    Neutral: {
+      container: 'bg-card border-border',
+      text: 'text-foreground',
+      description: 'text-muted-foreground',
+      icon: '',
+    },
+    Error: {
+      container: 'bg-card border-border',
+      text: 'text-destructive-foreground',
+      description: 'text-destructive-foreground',
+      icon: 'text-destructive-foreground',
+    },
+  };
+
+  const styles = typeStyles[type];
+  
+  const shouldShowIcon = showIcon ?? (icon !== undefined);
+  const shouldShowButton = showButton ?? (action !== undefined);
+  const shouldShowLine2 = showLine2 ?? (description !== undefined);
+  const iconPosition = flipIcon ? 'end' : 'start';
+
+  return (
+    <div 
+      className={cn(
+        'flex items-center gap-4 rounded-lg border p-4 shadow-sm',
+        styles.container,
+        className
+      )}
+      role="alert"
+    >
+      <div className="flex flex-1 items-start gap-3">
+        {shouldShowIcon && iconPosition === 'start' && icon && (
+          <div className={cn('flex shrink-0 items-center pt-[3px]', styles.icon)}>
+            {icon}
+          </div>
+        )}
+        
+        <div className="flex flex-1 flex-col gap-0.5">
+          <p className={cn('text-sm font-semibold leading-[21px] tracking-[0.07px]', styles.text)}>
+            {children}
+          </p>
+          {shouldShowLine2 && description && (
+            <p className={cn('text-sm font-normal leading-[21px] tracking-[0.07px]', styles.description)}>
+              {description}
+            </p>
+          )}
+        </div>
+        
+        {shouldShowIcon && iconPosition === 'end' && icon && (
+          <div className={cn('flex shrink-0 items-center pt-[3px]', styles.icon)}>
+            {icon}
+          </div>
+        )}
+      </div>
+      
+      {shouldShowButton && action && (
+        <div className="shrink-0">
+          {action}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/components/obra/Alert/README.md
+++ b/packages/client/src/components/obra/Alert/README.md
@@ -1,0 +1,48 @@
+# Alert
+
+Informational alert component that displays important messages to users with optional icon, description, and action button.
+
+## Figma Source
+
+https://www.figma.com/design/MQUbIrlfuM8qnr9XZ7jc82/Obra-shadcn-ui--Carton-?node-id=58-5416&t=I5A0QLIu4RNqO53t-4
+
+## Accepted Design Differences
+
+| Category | Figma | Implementation | File | Reason |
+|----------|-------|----------------|------|--------|
+| Width | Fixed 400px | Auto (100%) | Alert.tsx | Flexible responsive layout |
+| Icon Component | Complex nested SVG | React Icon prop | Alert.tsx | Flexible icon system |
+
+## Design-to-Code Mapping
+
+### Variant Mappings
+
+| Figma Variant | Figma Value | React Prop | React Value | Notes |
+|---------------|-------------|------------|-------------|-------|
+| Type | Neutral | `type` | `'Neutral'` | Gray/neutral styling |
+| Type | Error | `type` | `'Error'` | Red/error styling |
+
+### Property Mappings
+
+| Figma Property | Type | React Prop | Notes |
+|----------------|------|------------|-------|
+| Line 1 | Text | `children` | Primary alert text |
+| Line 2 | Text | `description` | Optional secondary text |
+| Show Line 2 | Boolean | `showLine2` | Controls description visibility |
+| Show Icon | Boolean | `showIcon` | Controls icon visibility |
+| Icon | Instance | `icon` | React icon component/element |
+| Flip Icon | Boolean | `flipIcon` | Controls icon placement (false=start, true=end) |
+| Show Button | Boolean | `showButton` | Controls action button visibility |
+| Button | Instance | `action` | React button component/element |
+
+### Excluded Properties (CSS/Internal)
+
+| Figma Property | Handling | Reason |
+|----------------|----------|--------|
+| Border Color | Tailwind utility classes | Controlled by type variant |
+| Background Color | Tailwind utility classes | Controlled by type variant |
+| Padding/Spacing | Tailwind spacing tokens | Layout styling |
+
+## Component API
+
+See `types.ts` for the full component API.

--- a/packages/client/src/components/obra/Alert/index.ts
+++ b/packages/client/src/components/obra/Alert/index.ts
@@ -1,0 +1,2 @@
+export { Alert } from './Alert';
+export type { AlertProps } from './types';

--- a/packages/client/src/components/obra/Alert/types.ts
+++ b/packages/client/src/components/obra/Alert/types.ts
@@ -1,0 +1,67 @@
+import { ReactNode } from "react";
+
+export interface AlertProps {
+  /**
+   * Alert type
+   * @default 'Neutral'
+   * @figma Variant: Type
+   */
+  type?: 'Neutral' | 'Error';
+  
+  /**
+   * Primary alert text (Line 1)
+   * @figma Text: Line 1
+   */
+  children: ReactNode;
+  
+  /**
+   * Optional secondary text (Line 2)
+   * @figma Text: Line 2
+   */
+  description?: string;
+  
+  /**
+   * Whether to show Line 2
+   * @default false (or true when description is provided)
+   * @figma Boolean: Show Line 2
+   */
+  showLine2?: boolean;
+  
+  /**
+   * Icon element to display
+   * @figma Instance: Icon
+   */
+  icon?: ReactNode;
+  
+  /**
+   * Whether to show the icon
+   * @default false (or true when icon is provided)
+   * @figma Boolean: Show Icon
+   */
+  showIcon?: boolean;
+  
+  /**
+   * Whether to flip icon to the right side
+   * @default false
+   * @figma Boolean: Flip Icon
+   */
+  flipIcon?: boolean;
+  
+  /**
+   * Action button element
+   * @figma Instance: Button
+   */
+  action?: ReactNode;
+  
+  /**
+   * Whether to show the action button
+   * @default false (or true when action is provided)
+   * @figma Boolean: Show Button
+   */
+  showButton?: boolean;
+  
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+}

--- a/packages/client/src/components/obra/index.ts
+++ b/packages/client/src/components/obra/index.ts
@@ -1,3 +1,6 @@
+export { Alert } from './Alert';
+export type { AlertProps } from './Alert';
+
 export { AlertDialog } from './AlertDialog';
 export type { AlertDialogProps } from './AlertDialog';
 


### PR DESCRIPTION
## Implemented the obra alert component 


### Source of failures:

#### Alert: 

**Figma Design** 
- The variants of the designs are not included as part of the component set, only a small set of them are. So the mcp does not get to access the full list of variants

**Prompt** 
- The color of the icon of the error state was incorrect

