### PR TITLE
Component reuse SKILL

### DIFF
--- a/.github/skills/component-reuse/SKILL.md
+++ b/.github/skills/component-reuse/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: component-reuse
+description: Ensure existing UI components are reused before creating new ones. Use when implementing any UI from Figma designs, tickets, or mockups. Requires a component audit to search the codebase before creating new components. If a component doesn't exist, delegates to figma-implement-component skill.
+---
+
+# Skill: Component Reuse
+
+This skill ensures existing components are discovered and reused before creating new ones. It prevents duplicate components and maintains design system consistency.
+
+## When to Use
+
+- Before implementing any UI element from a Figma design
+- When a ticket or task requires adding UI components to a page
+- Before creating any new component file
+- When you see a component name in Figma that might already exist in the codebase
+
+## When NOT to Use
+
+- For non-UI code (APIs, utilities, hooks)
+- When explicitly told to create a new component regardless of existing ones
+
+## Why This Matters
+
+Figma component names often differ from codebase component names. For example:
+- Figma calls it "Toast" → Codebase has "Alert"
+- Figma calls it "Input Field" → Codebase has "TextField"
+- Figma calls it "CTA Button" → Codebase has "Button"
+
+Skipping the audit leads to duplicate components with slightly different names.
+
+## Workflow Overview
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 1. EXTRACT - List all components referenced in the design      │
+├─────────────────────────────────────────────────────────────────┤
+│ 2. SEARCH - For each component, search codebase thoroughly     │
+├─────────────────────────────────────────────────────────────────┤
+│ 3. DOCUMENT - Output audit results before any implementation   │
+├─────────────────────────────────────────────────────────────────┤
+│ 4. DECIDE - Reuse existing OR delegate to figma-implement      │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Step-by-Step Instructions
+
+### Step 1: Extract Component References
+
+Before writing any UI code, identify all components needed:
+
+1. **From Figma designs**: Check component names, annotations, and linked design system references
+2. **From ticket/requirements**: Note any UI elements mentioned
+3. **From mockups/screenshots**: Identify recognizable UI patterns
+
+Create a list of all components you'll need to implement.
+
+### Step 2: Search the Codebase
+
+For **each component** identified, perform a thorough search:
+
+**Search strategies (use ALL of these):**
+
+1. **Exact name**: Search for the exact component name from Figma
+2. **Design system prefix**: If the project uses a prefix (e.g., `Acme`, `DS`), search with and without it
+3. **Synonyms and related terms**: Search for functionally equivalent names
+   - Notification → Alert, Toast, Snackbar, Message, Banner
+   - Modal → Dialog, Popup, Overlay
+   - Input → TextField, TextInput, Field
+   - Dropdown → Select, Combobox, Picker
+   - Card → Panel, Tile, Container
+4. **Partial matches**: Search for root words (e.g., "button" finds "IconButton", "ButtonGroup")
+
+**Search locations:**
+
+- `components/` directory and subdirectories
+- `ui/` directory
+- Any design system or shared component folders
+- `packages/` in monorepos
+
+**Search commands:**
+```bash
+# Search for component files
+find . -type f -name "*.tsx" | xargs grep -l "ComponentName"
+
+# Search for exports
+grep -r "export.*ComponentName" --include="*.ts" --include="*.tsx"
+
+# Search in common component directories
+ls -la src/components/
+ls -la packages/*/src/components/
+```
+
+### Step 3: Document Audit Results
+
+**REQUIRED**: Output an audit table before proceeding with any implementation.
+```
+## Component Audit Results
+
+| Figma Component | Search Terms Used | Codebase Match | Action |
+|-----------------|-------------------|----------------|--------|
+| Toast | toast, alert, notification, snackbar | src/components/Alert/Alert.tsx | REUSE |
+| Action Button | button, action-button, cta | src/components/Button/Button.tsx | REUSE |
+| User Card | card, user-card, profile-card | NOT FOUND | CREATE |
+```
+
+### Step 4: Take Action
+
+**For components marked REUSE:**
+- Import and use the existing component
+- Adapt props as needed to match the design
+- Do NOT create a wrapper or duplicate
+
+**For components marked CREATE:**
+- Invoke the `figma-implement-component` skill
+- Wait for component creation to complete
+- Then use the newly created component
+
+## Red Flags - Stop and Re-Search
+
+**STOP** if you're about to create a component that:
+
+- Has a generic/common name (Button, Input, Modal, Card, Alert, Toast, Dialog, etc.)
+- Serves a common UI purpose (feedback, navigation, form input, layout)
+- Looks similar to something you've seen elsewhere in the codebase
+
+These almost certainly already exist. Run additional searches with different terms.
+
+## Integration with Other Skills
+
+This skill works as a **gate** before other implementation skills:
+```
+User Request → component-reuse (audit) → Implementation
+                                      ↓
+                         figma-implement-component (if CREATE)
+```
+
+When implementing features from tickets:
+1. Run component-reuse audit FIRST
+2. For missing components, delegate to figma-implement-component
+3. Continue with feature implementation using existing + newly created components
+
+## Examples
+
+### Example 1: Toast Already Exists as Alert
+
+**Figma shows**: "Toast" component for success messages
+
+**Audit process**:
+```
+Search: "toast" → No results
+Search: "alert" → Found src/components/Alert/Alert.tsx
+Search: "notification" → Found src/components/Alert/Alert.tsx (same file)
+
+Reviewing Alert.tsx... supports: success, error, warning, info variants
+This matches the Toast functionality needed.
+```
+
+**Audit output**:
+```
+| Figma Component | Search Terms Used | Codebase Match | Action |
+|-----------------|-------------------|----------------|--------|
+| Toast | toast, alert, notification | src/components/Alert/Alert.tsx | REUSE |
+```
+
+**Action**: Import and use Alert component, do NOT create Toast.
+
+### Example 2: Component Genuinely Missing
+
+**Figma shows**: "Rating Stars" component
+
+**Audit process**:
+```
+Search: "rating" → No results
+Search: "stars" → No results  
+Search: "score" → No results
+Search: "review" → No results
+Searched components/, ui/, packages/ → Nothing similar found
+```
+
+**Audit output**:
+```
+| Figma Component | Search Terms Used | Codebase Match | Action |
+|-----------------|-------------------|----------------|--------|
+| Rating Stars | rating, stars, score, review | NOT FOUND | CREATE |
+```
+
+**Action**: Invoke `figma-implement-component` skill to create RatingStars component.
+
+## Common Mistakes to Avoid
+
+1. **Searching only the exact Figma name** - Always search synonyms
+2. **Creating before searching** - The audit MUST complete before any file creation
+3. **Assuming "not found" after one search** - Use multiple search strategies
+4. **Creating wrappers** - If a component exists, use it directly; don't wrap it
+5. **Ignoring design system folders** - Check for shared/common component libraries
+
+## Quality Checklist
+
+Before proceeding to implementation:
+
+- [ ] Listed all components needed from the design
+- [ ] Searched using at least 3 different terms per component
+- [ ] Checked all likely directories for existing components
+- [ ] Output the audit table with clear REUSE/CREATE decisions
+- [ ] For REUSE: Verified the existing component meets the design requirements
+- [ ] For CREATE: Ready to invoke figma-implement-component skill

--- a/.github/skills/figma-design-react/SKILL.md
+++ b/.github/skills/figma-design-react/SKILL.md
@@ -381,7 +381,7 @@ See full details: `.temp/design-components/button/proposed-api.md`
 
 ## Related Skills
 
-- **implement-component**: Use this skill next to build the component from the analysis
+- **figma-implement-component**: Use this skill next to build the component from the analysis
 - **create-react-modlet**: Defines the modlet folder structure for components
 - **figma-connect-component**: Detailed Code Connect mapping guidance
 - **figma-component-sync**: Use to check existing implementations against Figma designs

--- a/.github/skills/figma-implement-component/SKILL.md
+++ b/.github/skills/figma-implement-component/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: implement-component
+name: figma-implement-component
 description: Implement React components from Figma designs. Use after figma-design-react has analyzed the design. Delegates to create-react-modlet for folder structure, then adds Figma-specific implementation, stories for each variant, Code Connect mapping, and README with design context.
 ---
 


### PR DESCRIPTION
Adds a new skill 	`component-reuse` that requires a component audit before creating any new UI component:

Extract all components referenced in the design
Search the codebase for existing matches (by name, function, and visual similarity)
Document findings before implementation
Reuse existing components or delegate to figma-implement-component if truly new