### PR TITLE
FIX: No longer changing value of NODE_ENV

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -42,11 +42,11 @@ resource "aws_ecs_task_definition" "main" {
         {
           name  = "DATABASE_URL"
           value = "file:./db/dev.db"
-        },
-        {
-          name  = "NODE_ENV"
-          value = var.environment
         }
+        #        {
+        #  name  = "NODE_ENV"
+        #  value = var.environment
+        #}
       ]
 
       mountPoints = []


### PR DESCRIPTION
Since the production build has not been fully tested out, we are forcing both the production and staging environments to use the `NODE_ENV=development` convention until after the training sessions on February 26 and 27, 2026.