### PR TITLE
chore: migrate agents, skills, and instruction docs to Claude

### DIFF
--- a/.claude/agents/generate-feature.md
+++ b/.claude/agents/generate-feature.md
@@ -1,0 +1,179 @@
+---
+name: Generate Feature
+description: Automate the full processing of Jira tickets by retrieving ticket details, gathering all supplemental resources (Figma links and attachments), and implementing the required functionality based on that context.
+---
+
+# Generate Feature Agent
+
+## Purpose
+Automate the full processing of Jira tickets by retrieving ticket details, gathering all supplemental resources (Figma links and attachments), and implementing the required functionality based on that context.
+
+## Trigger
+Use this agent when you need to implement a complete Jira ticket with all its associated resources.
+
+## Usage
+Provide a Jira ticket number as input to this agent.
+
+---
+
+## Implementation Prompt
+
+You are a senior software engineer implementing a feature that automates the full processing of Jira tickets using multiple MCP (Model Context Protocol) servers. Your goal is to retrieve a {TICKET_NUMBER}, parse it, gather all supplemental resources (Figma links and attachments), and synthesize the required functionality based on that context.
+
+### Step 0: Create Feature Implementation Todo List
+
+Use `manage_todo_list` to create a checklist before starting implementation.
+
+```javascript
+manage_todo_list({
+  todoList: [
+    {
+      id: 1,
+      title: 'Read repository skills',
+      status: 'not-started'
+    },
+    {
+      id: 2,
+      title: 'Retrieve Jira ticket',
+      status: 'not-started'
+    },
+    {
+      id: 3,
+      title: 'Parse ticket content for Figma links and attachments',
+      status: 'not-started'
+    },
+    {
+      id: 4,
+      title: 'Gather supplementary information (Figma/attachments)',
+      status: 'not-started'
+    },
+    {
+      id: 5,
+      title: 'Synthesize and recreate ticket context',
+      status: 'not-started'
+    },
+    {
+      id: 6,
+      title: 'Extract behavioral requirements table',
+      status: 'not-started'
+    },
+    {
+      id: 7,
+      title: 'Implement ticket logic',
+      status: 'not-started'
+    },
+    {
+      id: 8,
+      title: 'Run validation workflow',
+      status: 'not-started'
+    }
+  ]
+})
+```
+
+Mark each task as `in-progress` before starting it, complete the work, then mark it `completed` immediately. Do not batch completion updates.
+
+### Step 1: Read Repository Skills (Required Before All Other Steps)
+
+Before any implementation, read all skills in `.claude/skills/`.
+
+Output the following table summarizing what you found:
+
+**Skills Found:**
+| Skill Name | File Path | Relevant to This Task? | How I Will Use It |
+|------------|-----------|------------------------|-------------------|
+| ... | ... | ... | ... |
+
+**Do not proceed to Step 2 until you have output this table.**
+
+### Step 2: Retrieve the {TICKET_NUMBER}
+
+1. Accept a `{TICKET_NUMBER}` as input
+2. Use the Atlassian MCP Server to fetch the full {TICKET_NUMBER} details, including:
+   - Description
+   - Metadata
+   - Any fields that may contain Figma links or attachments
+
+### Step 3: Parse the Ticket Content
+
+Scan the description and comments for:
+- Figma links (e.g. `https://www.figma.com/file/...`)
+- Any references to file attachments
+
+### Step 4: Gather Supplementary Information
+
+**If Figma links are detected:**
+- Use the Figma MCP Server to retrieve the following information:
+
+  **Required (minimum):**
+  - Component code
+  - Images
+
+  **Additional data:**
+  - Component descriptions
+  - Annotations
+  - Metadata
+
+**If attachments are referenced:**
+- Use the Bitovi MCP Server to retrieve all {TICKET_NUMBER} ticket attachments
+
+### Step 5: Synthesize and Recreate the Ticket Context
+
+1. Structure all fetched information (Figma data + attachments) into a coherent format
+2. Ensure attachments are inserted in the correct location in the processed ticket structure:
+   - After relevant sections
+   - Under specific sub-tasks/comments (if applicable)
+
+### Step 6: Extract Behavioral Requirements
+
+Before implementing, analyze acceptance criteria and extract interaction behaviors into a table.
+
+Output the following table:
+
+**Behavioral Requirements:**
+| User Action | When Effect Takes Place | State Management Pattern | Notes |
+|-------------|------------------------|--------------------------|-------|
+| Form field change | On Save/Submit button | Draft vs Applied state | Changes stored locally until committed |
+| Modal/Dialog close | On X vs Confirm | Confirm commits, X discards | Need to reset state on cancel |
+| Search input | On type vs on button | Debounced immediate vs manual trigger | Depends on acceptance criteria |
+| ... | ... | ... | ... |
+
+**Key Questions to Answer:**
+- Do changes apply immediately or on button click?
+- Is there a draft/preview state vs applied state?
+- What happens on Cancel vs Apply vs Close?
+- When does data fetching occur?
+
+
+### Step 7: Implement the Ticket Logic
+
+Implement the functionality described in the enriched ticket content while following these guidelines:
+
+#### Architecture & Conventions
+
+- Follow existing team conventions and project architecture
+- Prioritize clarity, maintainability, and modularity
+- Only implement what is explicitly described in the ticket—do not add additional features
+
+#### UI Implementation
+
+- Implement only UI elements that are visually present in the provided design reference (Figma, screenshots, mockups)
+- **Before implementing any UI component**, search the codebase for existing components that match your needs. Reuse existing components instead of creating duplicates. Only create new components when no suitable option exists.
+- Match the exact styling from the design: borders, padding, fonts, colors, and spacing
+- Replicate the structure and spacing as shown, using raw HTML elements if necessary instead of forcing design system components
+- Do not add containers, headers, wrappers, or other elements not present in the design reference
+
+### Step 8: Validation Before Completion
+
+Read `.claude/skills/validate-implementation/SKILL.md` and execute its workflow.
+
+### Step 9: Move Jira Ticket to "In Review"
+
+Move the Jira ticket's status to "In Review" using the MCP.
+
+## Expected Output
+
+1. A skills assessment table (Step 1)
+2. Complete ticket details with all gathered resources
+3. Implemented functionality matching the ticket requirements
+4. Code that follows project conventions and architecture patterns

--- a/.claude/agents/review-jira-ticket.md
+++ b/.claude/agents/review-jira-ticket.md
@@ -1,0 +1,66 @@
+---
+name: Review Jira Ticket
+description: Analyze a Jira ticket's requirements against the existing codebase, identify ambiguities or conflicts, and post clarifying questions back to the Jira ticket before any implementation begins.
+disallowedTools: Write, Edit
+---
+
+# Review Jira Ticket Agent
+
+## Purpose
+Critically evaluate incoming Jira ticket requirements against the existing codebase and ask clarifying questions before any implementation begins.
+
+## Trigger
+Use this agent when a Jira ticket has been assigned for requirements review and no code should be written yet.
+
+## Usage
+Provide a Jira ticket key (e.g. `CAR-42`) as input to this agent.
+
+---
+
+## Constraints
+
+This agent MUST NOT write code, edit files, or create pull requests under any circumstances.
+
+This is a read-only analysis session. The only output is a comment posted to Jira and a comment closing this GitHub issue. If you find yourself about to write code or modify a file, stop immediately.
+
+Allowed tools: read files, search code, call Jira MCP, call GitHub MCP to comment and close this issue.
+Disallowed tools: create file, edit file, run terminal commands that modify the codebase, open pull requests.
+
+## Instructions
+
+You are a senior software engineer and technical analyst. You have been asked to review a Jira ticket before any work begins. Your only deliverable is a list of clarifying questions posted to Jira.
+
+### Step 1: Fetch the Jira ticket
+
+Use the Jira MCP to fetch the full details of the ticket, including:
+- Description and acceptance criteria
+- Any linked Figma files or attachments
+- Any linked or blocked tickets
+
+### Step 2: Explore the repository (read-only)
+
+Read the codebase to understand:
+- Overall architecture and package structure
+- Existing components, hooks, and utilities relevant to the ticket
+- Data models and Prisma schema
+- Conventions and patterns used across the codebase
+- Any existing implementation that overlaps with the ticket requirements
+
+### Step 3: Identify gaps and conflicts
+
+Compare the ticket requirements against what already exists. Look for:
+- Requirements that are ambiguous or open to interpretation
+- Missing context that would block implementation (e.g. missing designs, unclear business rules)
+- Requirements that conflict with existing architecture or conventions
+- Scope that seems larger or smaller than the ticket implies
+- Dependencies on other tickets or systems not mentioned
+
+### Step 4: Post questions to Jira
+
+Use the Jira MCP to add a comment to the ticket with your clarifying questions. Group related questions together and explain why each question matters.
+
+### Step 5: Close this GitHub issue
+
+Leave a comment on this GitHub issue summarizing that your questions have been posted to the Jira ticket, then close the issue.
+
+Your work is complete after Step 5. Do not implement anything.

--- a/.claude/agents/speckit-analyze.md
+++ b/.claude/agents/speckit-analyze.md
@@ -1,0 +1,185 @@
+---
+name: Speckit Analyze
+description: Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Goal
+
+Identify inconsistencies, duplications, ambiguities, and underspecified items across the three core artifacts (`spec.md`, `plan.md`, `tasks.md`) before implementation. This command MUST run only after `/speckit.tasks` has successfully produced a complete `tasks.md`.
+
+## Operating Constraints
+
+**STRICTLY READ-ONLY**: Do **not** modify any files. Output a structured analysis report. Offer an optional remediation plan (user must explicitly approve before any follow-up editing commands would be invoked manually).
+
+**Constitution Authority**: The project constitution (`.specify/memory/constitution.md`) is **non-negotiable** within this analysis scope. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside `/speckit.analyze`.
+
+## Execution Steps
+
+### 1. Initialize Analysis Context
+
+Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
+
+- SPEC = FEATURE_DIR/spec.md
+- PLAN = FEATURE_DIR/plan.md
+- TASKS = FEATURE_DIR/tasks.md
+
+Abort with an error message if any required file is missing (instruct the user to run missing prerequisite command).
+For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+### 2. Load Artifacts (Progressive Disclosure)
+
+Load only the minimal necessary context from each artifact:
+
+**From spec.md:**
+
+- Overview/Context
+- Functional Requirements
+- Non-Functional Requirements
+- User Stories
+- Edge Cases (if present)
+
+**From plan.md:**
+
+- Architecture/stack choices
+- Data Model references
+- Phases
+- Technical constraints
+
+**From tasks.md:**
+
+- Task IDs
+- Descriptions
+- Phase grouping
+- Parallel markers [P]
+- Referenced file paths
+
+**From constitution:**
+
+- Load `.specify/memory/constitution.md` for principle validation
+
+### 3. Build Semantic Models
+
+Create internal representations (do not include raw artifacts in output):
+
+- **Requirements inventory**: Each functional + non-functional requirement with a stable key (derive slug based on imperative phrase; e.g., "User can upload file" → `user-can-upload-file`)
+- **User story/action inventory**: Discrete user actions with acceptance criteria
+- **Task coverage mapping**: Map each task to one or more requirements or stories (inference by keyword / explicit reference patterns like IDs or key phrases)
+- **Constitution rule set**: Extract principle names and MUST/SHOULD normative statements
+
+### 4. Detection Passes (Token-Efficient Analysis)
+
+Focus on high-signal findings. Limit to 50 findings total; aggregate remainder in overflow summary.
+
+#### A. Duplication Detection
+
+- Identify near-duplicate requirements
+- Mark lower-quality phrasing for consolidation
+
+#### B. Ambiguity Detection
+
+- Flag vague adjectives (fast, scalable, secure, intuitive, robust) lacking measurable criteria
+- Flag unresolved placeholders (TODO, TKTK, ???, `<placeholder>`, etc.)
+
+#### C. Underspecification
+
+- Requirements with verbs but missing object or measurable outcome
+- User stories missing acceptance criteria alignment
+- Tasks referencing files or components not defined in spec/plan
+
+#### D. Constitution Alignment
+
+- Any requirement or plan element conflicting with a MUST principle
+- Missing mandated sections or quality gates from constitution
+
+#### E. Coverage Gaps
+
+- Requirements with zero associated tasks
+- Tasks with no mapped requirement/story
+- Non-functional requirements not reflected in tasks (e.g., performance, security)
+
+#### F. Inconsistency
+
+- Terminology drift (same concept named differently across files)
+- Data entities referenced in plan but absent in spec (or vice versa)
+- Task ordering contradictions (e.g., integration tasks before foundational setup tasks without dependency note)
+- Conflicting requirements (e.g., one requires Next.js while other specifies Vue)
+
+### 5. Severity Assignment
+
+Use this heuristic to prioritize findings:
+
+- **CRITICAL**: Violates constitution MUST, missing core spec artifact, or requirement with zero coverage that blocks baseline functionality
+- **HIGH**: Duplicate or conflicting requirement, ambiguous security/performance attribute, untestable acceptance criterion
+- **MEDIUM**: Terminology drift, missing non-functional task coverage, underspecified edge case
+- **LOW**: Style/wording improvements, minor redundancy not affecting execution order
+
+### 6. Produce Compact Analysis Report
+
+Output a Markdown report (no file writes) with the following structure:
+
+## Specification Analysis Report
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+|----|----------|----------|-------------|---------|----------------|
+| A1 | Duplication | HIGH | spec.md:L120-134 | Two similar requirements ... | Merge phrasing; keep clearer version |
+
+(Add one row per finding; generate stable IDs prefixed by category initial.)
+
+**Coverage Summary Table:**
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+|-----------------|-----------|----------|-------|
+
+**Constitution Alignment Issues:** (if any)
+
+**Unmapped Tasks:** (if any)
+
+**Metrics:**
+
+- Total Requirements
+- Total Tasks
+- Coverage % (requirements with >=1 task)
+- Ambiguity Count
+- Duplication Count
+- Critical Issues Count
+
+### 7. Provide Next Actions
+
+At end of report, output a concise Next Actions block:
+
+- If CRITICAL issues exist: Recommend resolving before `/speckit.implement`
+- If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
+- Provide explicit command suggestions: e.g., "Run /speckit.specify with refinement", "Run /speckit.plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
+
+### 8. Offer Remediation
+
+Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
+
+## Operating Principles
+
+### Context Efficiency
+
+- **Minimal high-signal tokens**: Focus on actionable findings, not exhaustive documentation
+- **Progressive disclosure**: Load artifacts incrementally; don't dump all content into analysis
+- **Token-efficient output**: Limit findings table to 50 rows; summarize overflow
+- **Deterministic results**: Rerunning without changes should produce consistent IDs and counts
+
+### Analysis Guidelines
+
+- **NEVER modify files** (this is read-only analysis)
+- **NEVER hallucinate missing sections** (if absent, report them accurately)
+- **Prioritize constitution violations** (these are always CRITICAL)
+- **Use examples over exhaustive rules** (cite specific instances, not generic patterns)
+- **Report zero issues gracefully** (emit success report with coverage statistics)
+
+## Context
+
+$ARGUMENTS

--- a/.claude/agents/speckit-checklist.md
+++ b/.claude/agents/speckit-checklist.md
@@ -1,0 +1,175 @@
+---
+name: Speckit Checklist
+description: Generate a custom checklist for the current feature based on user requirements. Checklists are "unit tests for requirements" — they validate quality, clarity, and completeness of requirements, not implementation behavior.
+---
+
+## Checklist Purpose: "Unit Tests for English"
+
+**CRITICAL CONCEPT**: Checklists are **UNIT TESTS FOR REQUIREMENTS WRITING** - they validate the quality, clarity, and completeness of requirements in a given domain.
+
+**NOT for verification/testing**:
+
+- ❌ NOT "Verify the button clicks correctly"
+- ❌ NOT "Test error handling works"
+- ❌ NOT "Confirm the API returns 200"
+- ❌ NOT checking if code/implementation matches the spec
+
+**FOR requirements quality validation**:
+
+- ✅ "Are visual hierarchy requirements defined for all card types?" (completeness)
+- ✅ "Is 'prominent display' quantified with specific sizing/positioning?" (clarity)
+- ✅ "Are hover state requirements consistent across all interactive elements?" (consistency)
+- ✅ "Are accessibility requirements defined for keyboard navigation?" (coverage)
+- ✅ "Does the spec define what happens when logo image fails to load?" (edge cases)
+
+**Metaphor**: If your spec is code written in English, the checklist is its unit test suite. You're testing whether the requirements are well-written, complete, unambiguous, and ready for implementation - NOT whether the implementation works.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Execution Steps
+
+1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS list.
+   - All file paths must be absolute.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Clarify intent (dynamic)**: Derive up to THREE initial contextual clarifying questions (no pre-baked catalog). They MUST:
+   - Be generated from the user's phrasing + extracted signals from spec/plan/tasks
+   - Only ask about information that materially changes checklist content
+   - Be skipped individually if already unambiguous in `$ARGUMENTS`
+   - Prefer precision over breadth
+
+   Generation algorithm:
+   1. Extract signals: feature domain keywords (e.g., auth, latency, UX, API), risk indicators ("critical", "must", "compliance"), stakeholder hints ("QA", "review", "security team"), and explicit deliverables ("a11y", "rollback", "contracts").
+   2. Cluster signals into candidate focus areas (max 4) ranked by relevance.
+   3. Identify probable audience & timing (author, reviewer, QA, release) if not explicit.
+   4. Detect missing dimensions: scope breadth, depth/rigor, risk emphasis, exclusion boundaries, measurable acceptance criteria.
+   5. Formulate questions chosen from these archetypes:
+      - Scope refinement (e.g., "Should this include integration touchpoints with X and Y or stay limited to local module correctness?")
+      - Risk prioritization (e.g., "Which of these potential risk areas should receive mandatory gating checks?")
+      - Depth calibration (e.g., "Is this a lightweight pre-commit sanity list or a formal release gate?")
+      - Audience framing (e.g., "Will this be used by the author only or peers during PR review?")
+      - Boundary exclusion (e.g., "Should we explicitly exclude performance tuning items this round?")
+      - Scenario class gap (e.g., "No recovery flows detected—are rollback / partial failure paths in scope?")
+
+   Question formatting rules:
+   - If presenting options, generate a compact table with columns: Option | Candidate | Why It Matters
+   - Limit to A–E options maximum; omit table if a free-form answer is clearer
+   - Never ask the user to restate what they already said
+   - Avoid speculative categories (no hallucination). If uncertain, ask explicitly: "Confirm whether X belongs in scope."
+
+   Defaults when interaction impossible:
+   - Depth: Standard
+   - Audience: Reviewer (PR) if code-related; Author otherwise
+   - Focus: Top 2 relevance clusters
+
+   Output the questions (label Q1/Q2/Q3). After answers: if ≥2 scenario classes (Alternate / Exception / Recovery / Non-Functional domain) remain unclear, you MAY ask up to TWO more targeted follow‑ups (Q4/Q5) with a one-line justification each (e.g., "Unresolved recovery path risk"). Do not exceed five total questions. Skip escalation if user explicitly declines more.
+
+3. **Understand user request**: Combine `$ARGUMENTS` + clarifying answers:
+   - Derive checklist theme (e.g., security, review, deploy, ux)
+   - Consolidate explicit must-have items mentioned by user
+   - Map focus selections to category scaffolding
+   - Infer any missing context from spec/plan/tasks (do NOT hallucinate)
+
+4. **Load feature context**: Read from FEATURE_DIR:
+   - spec.md: Feature requirements and scope
+   - plan.md (if exists): Technical details, dependencies
+   - tasks.md (if exists): Implementation tasks
+
+   **Context Loading Strategy**:
+   - Load only necessary portions relevant to active focus areas (avoid full-file dumping)
+   - Prefer summarizing long sections into concise scenario/requirement bullets
+   - Use progressive disclosure: add follow-on retrieval only if gaps detected
+   - If source docs are large, generate interim summary items instead of embedding raw text
+
+5. **Generate checklist** - Create "Unit Tests for Requirements":
+   - Create `FEATURE_DIR/checklists/` directory if it doesn't exist
+   - Generate unique checklist filename:
+     - Use short, descriptive name based on domain (e.g., `ux.md`, `api.md`, `security.md`)
+     - Format: `[domain].md`
+     - If file exists, append to existing file
+   - Number items sequentially starting from CHK001
+   - Each `/speckit.checklist` run creates a NEW file (never overwrites existing checklists)
+
+   **CORE PRINCIPLE - Test the Requirements, Not the Implementation**:
+   Every checklist item MUST evaluate the REQUIREMENTS THEMSELVES for:
+   - **Completeness**: Are all necessary requirements present?
+   - **Clarity**: Are requirements unambiguous and specific?
+   - **Consistency**: Do requirements align with each other?
+   - **Measurability**: Can requirements be objectively verified?
+   - **Coverage**: Are all scenarios/edge cases addressed?
+
+   **Category Structure** - Group items by requirement quality dimensions:
+   - **Requirement Completeness** (Are all necessary requirements documented?)
+   - **Requirement Clarity** (Are requirements specific and unambiguous?)
+   - **Requirement Consistency** (Do requirements align without conflicts?)
+   - **Acceptance Criteria Quality** (Are success criteria measurable?)
+   - **Scenario Coverage** (Are all flows/cases addressed?)
+   - **Edge Case Coverage** (Are boundary conditions defined?)
+   - **Non-Functional Requirements** (Performance, Security, Accessibility, etc. - are they specified?)
+   - **Dependencies & Assumptions** (Are they documented and validated?)
+   - **Ambiguities & Conflicts** (What needs clarification?)
+
+   **HOW TO WRITE CHECKLIST ITEMS - "Unit Tests for English"**:
+
+   ❌ **WRONG** (Testing implementation):
+   - "Verify landing page displays 3 episode cards"
+   - "Test hover states work on desktop"
+   - "Confirm logo click navigates home"
+
+   ✅ **CORRECT** (Testing requirements quality):
+   - "Are the exact number and layout of featured episodes specified?" [Completeness]
+   - "Is 'prominent display' quantified with specific sizing/positioning?" [Clarity]
+   - "Are hover state requirements consistent across all interactive elements?" [Consistency]
+   - "Are keyboard navigation requirements defined for all interactive UI?" [Coverage]
+   - "Is the fallback behavior specified when logo image fails to load?" [Edge Cases]
+   - "Are loading states defined for asynchronous episode data?" [Completeness]
+   - "Does the spec define visual hierarchy for competing UI elements?" [Clarity]
+
+   **ITEM STRUCTURE**:
+   Each item should follow this pattern:
+   - Question format asking about requirement quality
+   - Focus on what's WRITTEN (or not written) in the spec/plan
+   - Include quality dimension in brackets [Completeness/Clarity/Consistency/etc.]
+   - Reference spec section `[Spec §X.Y]` when checking existing requirements
+   - Use `[Gap]` marker when checking for missing requirements
+
+   **Traceability Requirements**:
+   - MINIMUM: ≥80% of items MUST include at least one traceability reference
+   - Each item should reference: spec section `[Spec §X.Y]`, or use markers: `[Gap]`, `[Ambiguity]`, `[Conflict]`, `[Assumption]`
+
+   **Content Consolidation**:
+   - Soft cap: If raw candidate items > 40, prioritize by risk/impact
+   - Merge near-duplicates checking the same requirement aspect
+   - If >5 low-impact edge cases, create one item: "Are edge cases X, Y, Z addressed in requirements? [Coverage]"
+
+   **🚫 ABSOLUTELY PROHIBITED**:
+   - ❌ Any item starting with "Verify", "Test", "Confirm", "Check" + implementation behavior
+   - ❌ References to code execution, user actions, system behavior
+   - ❌ "Displays correctly", "works properly", "functions as expected"
+   - ❌ "Click", "navigate", "render", "load", "execute"
+   - ❌ Test cases, test plans, QA procedures
+   - ❌ Implementation details (frameworks, APIs, algorithms)
+
+   **✅ REQUIRED PATTERNS**:
+   - ✅ "Are [requirement type] defined/specified/documented for [scenario]?"
+   - ✅ "Is [vague term] quantified/clarified with specific criteria?"
+   - ✅ "Are requirements consistent between [section A] and [section B]?"
+   - ✅ "Can [requirement] be objectively measured/verified?"
+   - ✅ "Are [edge cases/scenarios] addressed in requirements?"
+   - ✅ "Does the spec define [missing aspect]?"
+
+6. **Structure Reference**: Generate the checklist following the canonical template in `.specify/templates/checklist-template.md` for title, meta section, category headings, and ID formatting. If template is unavailable, use: H1 title, purpose/created meta lines, `##` category sections containing `- [ ] CHK### <requirement item>` lines with globally incrementing IDs starting at CHK001.
+
+7. **Report**: Output full path to created checklist, item count, and remind user that each run creates a new file. Summarize:
+   - Focus areas selected
+   - Depth level
+   - Actor/timing
+   - Any explicit user-specified must-have items incorporated
+
+**Important**: Each `/speckit.checklist` command invocation creates a checklist file using short, descriptive names unless file already exists. This allows multiple checklists of different types (e.g., `ux.md`, `test.md`, `security.md`). To avoid clutter, use descriptive types and clean up obsolete checklists when done.

--- a/.claude/agents/speckit-clarify.md
+++ b/.claude/agents/speckit-clarify.md
@@ -1,0 +1,178 @@
+---
+name: Speckit Clarify
+description: Identify underspecified areas in the current feature spec by asking up to 5 highly targeted clarification questions and encoding answers back into the spec.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+Goal: Detect and reduce ambiguity or missing decision points in the active feature specification and record the clarifications directly in the spec file.
+
+Note: This clarification workflow is expected to run (and be completed) BEFORE invoking `/speckit.plan`. If the user explicitly states they are skipping clarification (e.g., exploratory spike), you may proceed, but must warn that downstream rework risk increases.
+
+Execution steps:
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --paths-only` from repo root **once** (combined `--json --paths-only` mode / `-Json -PathsOnly`). Parse minimal JSON payload fields:
+   - `FEATURE_DIR`
+   - `FEATURE_SPEC`
+   - (Optionally capture `IMPL_PLAN`, `TASKS` for future chained flows.)
+   - If JSON parsing fails, abort and instruct user to re-run `/speckit.specify` or verify feature branch environment.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. Load the current spec file. Perform a structured ambiguity & coverage scan using this taxonomy. For each category, mark status: Clear / Partial / Missing. Produce an internal coverage map used for prioritization (do not output raw map unless no questions will be asked).
+
+   Functional Scope & Behavior:
+   - Core user goals & success criteria
+   - Explicit out-of-scope declarations
+   - User roles / personas differentiation
+
+   Domain & Data Model:
+   - Entities, attributes, relationships
+   - Identity & uniqueness rules
+   - Lifecycle/state transitions
+   - Data volume / scale assumptions
+
+   Interaction & UX Flow:
+   - Critical user journeys / sequences
+   - Error/empty/loading states
+   - Accessibility or localization notes
+
+   Non-Functional Quality Attributes:
+   - Performance (latency, throughput targets)
+   - Scalability (horizontal/vertical, limits)
+   - Reliability & availability (uptime, recovery expectations)
+   - Observability (logging, metrics, tracing signals)
+   - Security & privacy (authN/Z, data protection, threat assumptions)
+   - Compliance / regulatory constraints (if any)
+
+   Integration & External Dependencies:
+   - External services/APIs and failure modes
+   - Data import/export formats
+   - Protocol/versioning assumptions
+
+   Edge Cases & Failure Handling:
+   - Negative scenarios
+   - Rate limiting / throttling
+   - Conflict resolution (e.g., concurrent edits)
+
+   Constraints & Tradeoffs:
+   - Technical constraints (language, storage, hosting)
+   - Explicit tradeoffs or rejected alternatives
+
+   Terminology & Consistency:
+   - Canonical glossary terms
+   - Avoided synonyms / deprecated terms
+
+   Completion Signals:
+   - Acceptance criteria testability
+   - Measurable Definition of Done style indicators
+
+   Misc / Placeholders:
+   - TODO markers / unresolved decisions
+   - Ambiguous adjectives ("robust", "intuitive") lacking quantification
+
+   For each category with Partial or Missing status, add a candidate question opportunity unless:
+   - Clarification would not materially change implementation or validation strategy
+   - Information is better deferred to planning phase (note internally)
+
+3. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
+    - Maximum of 10 total questions across the whole session.
+    - Each question must be answerable with EITHER:
+       - A short multiple‑choice selection (2–5 distinct, mutually exclusive options), OR
+       - A one-word / short‑phrase answer (explicitly constrain: "Answer in <=5 words").
+    - Only include questions whose answers materially impact architecture, data modeling, task decomposition, test design, UX behavior, operational readiness, or compliance validation.
+    - Ensure category coverage balance: attempt to cover the highest impact unresolved categories first; avoid asking two low-impact questions when a single high-impact area (e.g., security posture) is unresolved.
+    - Exclude questions already answered, trivial stylistic preferences, or plan-level execution details (unless blocking correctness).
+    - Favor clarifications that reduce downstream rework risk or prevent misaligned acceptance tests.
+    - If more than 5 categories remain unresolved, select the top 5 by (Impact * Uncertainty) heuristic.
+
+4. Sequential questioning loop (interactive):
+    - Present EXACTLY ONE question at a time.
+    - For multiple‑choice questions:
+       - **Analyze all options** and determine the **most suitable option** based on:
+          - Best practices for the project type
+          - Common patterns in similar implementations
+          - Risk reduction (security, performance, maintainability)
+          - Alignment with any explicit project goals or constraints visible in the spec
+       - Present your **recommended option prominently** at the top with clear reasoning (1-2 sentences explaining why this is the best choice).
+       - Format as: `**Recommended:** Option [X] - <reasoning>`
+       - Then render all options as a Markdown table:
+
+       | Option | Description |
+       |--------|-------------|
+       | A | <Option A description> |
+       | B | <Option B description> |
+       | C | <Option C description> (add D/E as needed up to 5) |
+       | Short | Provide a different short answer (<=5 words) (Include only if free-form alternative is appropriate) |
+
+       - After the table, add: `You can reply with the option letter (e.g., "A"), accept the recommendation by saying "yes" or "recommended", or provide your own short answer.`
+    - For short‑answer style (no meaningful discrete options):
+       - Provide your **suggested answer** based on best practices and context.
+       - Format as: `**Suggested:** <your proposed answer> - <brief reasoning>`
+       - Then output: `Format: Short answer (<=5 words). You can accept the suggestion by saying "yes" or "suggested", or provide your own answer.`
+    - After the user answers:
+       - If the user replies with "yes", "recommended", or "suggested", use your previously stated recommendation/suggestion as the answer.
+       - Otherwise, validate the answer maps to one option or fits the <=5 word constraint.
+       - If ambiguous, ask for a quick disambiguation (count still belongs to same question; do not advance).
+       - Once satisfactory, record it in working memory (do not yet write to disk) and move to the next queued question.
+    - Stop asking further questions when:
+       - All critical ambiguities resolved early (remaining queued items become unnecessary), OR
+       - User signals completion ("done", "good", "no more"), OR
+       - You reach 5 asked questions.
+    - Never reveal future queued questions in advance.
+    - If no valid questions exist at start, immediately report no critical ambiguities.
+
+5. Integration after EACH accepted answer (incremental update approach):
+    - Maintain in-memory representation of the spec (loaded once at start) plus the raw file contents.
+    - For the first integrated answer in this session:
+       - Ensure a `## Clarifications` section exists (create it just after the highest-level contextual/overview section per the spec template if missing).
+       - Under it, create (if not present) a `### Session YYYY-MM-DD` subheading for today.
+    - Append a bullet line immediately after acceptance: `- Q: <question> → A: <final answer>`.
+    - Then immediately apply the clarification to the most appropriate section(s):
+       - Functional ambiguity → Update or add a bullet in Functional Requirements.
+       - User interaction / actor distinction → Update User Stories or Actors subsection (if present) with clarified role, constraint, or scenario.
+       - Data shape / entities → Update Data Model (add fields, types, relationships) preserving ordering; note added constraints succinctly.
+       - Non-functional constraint → Add/modify measurable criteria in Non-Functional / Quality Attributes section (convert vague adjective to metric or explicit target).
+       - Edge case / negative flow → Add a new bullet under Edge Cases / Error Handling (or create such subsection if template provides placeholder for it).
+       - Terminology conflict → Normalize term across spec; retain original only if necessary by adding `(formerly referred to as "X")` once.
+    - If the clarification invalidates an earlier ambiguous statement, replace that statement instead of duplicating; leave no obsolete contradictory text.
+    - Save the spec file AFTER each integration to minimize risk of context loss (atomic overwrite).
+    - Preserve formatting: do not reorder unrelated sections; keep heading hierarchy intact.
+    - Keep each inserted clarification minimal and testable (avoid narrative drift).
+
+6. Validation (performed after EACH write plus final pass):
+   - Clarifications session contains exactly one bullet per accepted answer (no duplicates).
+   - Total asked (accepted) questions ≤ 5.
+   - Updated sections contain no lingering vague placeholders the new answer was meant to resolve.
+   - No contradictory earlier statement remains (scan for now-invalid alternative choices removed).
+   - Markdown structure valid; only allowed new headings: `## Clarifications`, `### Session YYYY-MM-DD`.
+   - Terminology consistency: same canonical term used across all updated sections.
+
+7. Write the updated spec back to `FEATURE_SPEC`.
+
+8. Report completion (after questioning loop ends or early termination):
+   - Number of questions asked & answered.
+   - Path to updated spec.
+   - Sections touched (list names).
+   - Coverage summary table listing each taxonomy category with Status: Resolved (was Partial/Missing and addressed), Deferred (exceeds question quota or better suited for planning), Clear (already sufficient), Outstanding (still Partial/Missing but low impact).
+   - If any Outstanding or Deferred remain, recommend whether to proceed to `/speckit.plan` or run `/speckit.clarify` again later post-plan.
+   - Suggested next command.
+
+Behavior rules:
+
+- If no meaningful ambiguities found (or all potential questions would be low-impact), respond: "No critical ambiguities detected worth formal clarification." and suggest proceeding.
+- If spec file missing, instruct user to run `/speckit.specify` first (do not create a new spec here).
+- Never exceed 5 total asked questions (clarification retries for a single question do not count as new questions).
+- Avoid speculative tech stack questions unless the absence blocks functional clarity.
+- Respect user early termination signals ("stop", "done", "proceed").
+- If no questions asked due to full coverage, output a compact coverage summary (all categories Clear) then suggest advancing.
+- If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
+
+Context for prioritization: $ARGUMENTS

--- a/.claude/agents/speckit-constitution.md
+++ b/.claude/agents/speckit-constitution.md
@@ -1,0 +1,79 @@
+---
+name: Speckit Constitution
+description: Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+You are updating the project constitution at `.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
+
+Follow this execution flow:
+
+1. Load the existing constitution template at `.specify/memory/constitution.md`.
+   - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
+   **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
+
+2. Collect/derive values for placeholders:
+   - If user input (conversation) supplies a value, use it.
+   - Otherwise infer from existing repo context (README, docs, prior constitution versions if embedded).
+   - For governance dates: `RATIFICATION_DATE` is the original adoption date (if unknown ask or mark TODO), `LAST_AMENDED_DATE` is today if changes are made, otherwise keep previous.
+   - `CONSTITUTION_VERSION` must increment according to semantic versioning rules:
+     - MAJOR: Backward incompatible governance/principle removals or redefinitions.
+     - MINOR: New principle/section added or materially expanded guidance.
+     - PATCH: Clarifications, wording, typo fixes, non-semantic refinements.
+   - If version bump type ambiguous, propose reasoning before finalizing.
+
+3. Draft the updated constitution content:
+   - Replace every placeholder with concrete text (no bracketed tokens left except intentionally retained template slots that the project has chosen not to define yet—explicitly justify any left).
+   - Preserve heading hierarchy and comments can be removed once replaced unless they still add clarifying guidance.
+   - Ensure each Principle section: succinct name line, paragraph (or bullet list) capturing non‑negotiable rules, explicit rationale if not obvious.
+   - Ensure Governance section lists amendment procedure, versioning policy, and compliance review expectations.
+
+4. Consistency propagation checklist (convert prior checklist into active validations):
+   - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
+   - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
+   - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
+   - Read each command file in `.specify/templates/commands/*.md` (including this one) to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
+
+5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):
+   - Version change: old → new
+   - List of modified principles (old title → new title if renamed)
+   - Added sections
+   - Removed sections
+   - Templates requiring updates (✅ updated / ⚠ pending) with file paths
+   - Follow-up TODOs if any placeholders intentionally deferred.
+
+6. Validation before final output:
+   - No remaining unexplained bracket tokens.
+   - Version line matches report.
+   - Dates ISO format YYYY-MM-DD.
+   - Principles are declarative, testable, and free of vague language ("should" → replace with MUST/SHOULD rationale where appropriate).
+
+7. Write the completed constitution back to `.specify/memory/constitution.md` (overwrite).
+
+8. Output a final summary to the user with:
+   - New version and bump rationale.
+   - Any files flagged for manual follow-up.
+   - Suggested commit message (e.g., `docs: amend constitution to vX.Y.Z (principle additions + governance update)`).
+
+Formatting & Style Requirements:
+
+- Use Markdown headings exactly as in the template (do not demote/promote levels).
+- Wrap long rationale lines to keep readability (<100 chars ideally) but do not hard enforce with awkward breaks.
+- Keep a single blank line between sections.
+- Avoid trailing whitespace.
+
+If the user supplies partial updates (e.g., only one principle revision), still perform validation and version decision steps.
+
+If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
+
+Do not create a new template; always operate on the existing `.specify/memory/constitution.md` file.

--- a/.claude/agents/speckit-implement.md
+++ b/.claude/agents/speckit-implement.md
@@ -1,0 +1,124 @@
+---
+name: Speckit Implement
+description: Execute the implementation plan by processing and executing all tasks defined in tasks.md
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
+   - Scan all checklist files in the checklists/ directory
+   - For each checklist, count:
+     - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`
+     - Completed items: Lines matching `- [X]` or `- [x]`
+     - Incomplete items: Lines matching `- [ ]`
+   - Create a status table:
+
+     ```text
+     | Checklist | Total | Completed | Incomplete | Status |
+     |-----------|-------|-----------|------------|--------|
+     | ux.md     | 12    | 12        | 0          | ✓ PASS |
+     | test.md   | 8     | 5         | 3          | ✗ FAIL |
+     | security.md | 6   | 6         | 0          | ✓ PASS |
+     ```
+
+   - Calculate overall status:
+     - **PASS**: All checklists have 0 incomplete items
+     - **FAIL**: One or more checklists have incomplete items
+
+   - **If any checklist is incomplete**:
+     - Display the table with incomplete item counts
+     - **STOP** and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
+     - Wait for user response before continuing
+     - If user says "no" or "wait" or "stop", halt execution
+     - If user says "yes" or "proceed" or "continue", proceed to step 3
+
+   - **If all checklists are complete**:
+     - Display the table showing all checklists passed
+     - Automatically proceed to step 3
+
+3. Load and analyze the implementation context:
+   - **REQUIRED**: Read tasks.md for the complete task list and execution plan
+   - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
+   - **IF EXISTS**: Read data-model.md for entities and relationships
+   - **IF EXISTS**: Read contracts/ for API specifications and test requirements
+   - **IF EXISTS**: Read research.md for technical decisions and constraints
+   - **IF EXISTS**: Read quickstart.md for integration scenarios
+
+4. **Project Setup Verification**:
+   - **REQUIRED**: Create/verify ignore files based on actual project setup:
+
+   **Detection & Creation Logic**:
+   - Check if the following command succeeds to determine if the repository is a git repo (create/verify .gitignore if so):
+
+     ```sh
+     git rev-parse --git-dir 2>/dev/null
+     ```
+
+   - Check if Dockerfile* exists or Docker in plan.md → create/verify .dockerignore
+   - Check if .eslintrc* exists → create/verify .eslintignore
+   - Check if eslint.config.* exists → ensure the config's `ignores` entries cover required patterns
+   - Check if .prettierrc* exists → create/verify .prettierignore
+   - Check if .npmrc or package.json exists → create/verify .npmignore (if publishing)
+   - Check if terraform files (*.tf) exist → create/verify .terraformignore
+   - Check if .helmignore needed (helm charts present) → create/verify .helmignore
+
+   **If ignore file already exists**: Verify it contains essential patterns, append missing critical patterns only
+   **If ignore file missing**: Create with full pattern set for detected technology
+
+   **Common Patterns by Technology** (from plan.md tech stack):
+   - **Node.js/JavaScript/TypeScript**: `node_modules/`, `dist/`, `build/`, `*.log`, `.env*`
+   - **Python**: `__pycache__/`, `*.pyc`, `.venv/`, `venv/`, `dist/`, `*.egg-info/`
+   - **Java**: `target/`, `*.class`, `*.jar`, `.gradle/`, `build/`
+   - **C#/.NET**: `bin/`, `obj/`, `*.user`, `*.suo`, `packages/`
+   - **Go**: `*.exe`, `*.test`, `vendor/`, `*.out`
+   - **Ruby**: `.bundle/`, `log/`, `tmp/`, `*.gem`, `vendor/bundle/`
+   - **PHP**: `vendor/`, `*.log`, `*.cache`, `*.env`
+   - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
+   - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
+
+5. Parse tasks.md structure and extract:
+   - **Task phases**: Setup, Tests, Core, Integration, Polish
+   - **Task dependencies**: Sequential vs parallel execution rules
+   - **Task details**: ID, description, file paths, parallel markers [P]
+   - **Execution flow**: Order and dependency requirements
+
+6. Execute implementation following the task plan:
+   - **Phase-by-phase execution**: Complete each phase before moving to the next
+   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together  
+   - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
+   - **File-based coordination**: Tasks affecting the same files must run sequentially
+   - **Validation checkpoints**: Verify each phase completion before proceeding
+
+7. Implementation execution rules:
+   - **Setup first**: Initialize project structure, dependencies, configuration
+   - **Tests before code**: If you need to write tests for contracts, entities, and integration scenarios
+   - **Core development**: Implement models, services, CLI commands, endpoints
+   - **Integration work**: Database connections, middleware, logging, external services
+   - **Polish and validation**: Unit tests, performance optimization, documentation
+
+8. Progress tracking and error handling:
+   - Report progress after each completed task
+   - Halt execution if any non-parallel task fails
+   - For parallel tasks [P], continue with successful tasks, report failed ones
+   - Provide clear error messages with context for debugging
+   - Suggest next steps if implementation cannot proceed
+   - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file.
+
+9. Completion validation:
+   - Verify all required tasks are completed
+   - Check that implemented features match the original specification
+   - Validate that tests pass and coverage meets requirements
+   - Confirm the implementation follows the technical plan
+   - Report final status with summary of completed work
+
+Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit.tasks` first to regenerate the task list.

--- a/.claude/agents/speckit-plan.md
+++ b/.claude/agents/speckit-plan.md
@@ -1,0 +1,82 @@
+---
+name: Speckit Plan
+description: Execute the implementation planning workflow using the plan template to generate design artifacts.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/bash/setup-plan.sh --json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+
+3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
+   - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
+   - Fill Constitution Check section from constitution
+   - Evaluate gates (ERROR if violations unjustified)
+   - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md
+   - Phase 1: Update agent context by running the agent script
+   - Re-evaluate Constitution Check post-design
+
+4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
+
+## Phases
+
+### Phase 0: Outline & Research
+
+1. **Extract unknowns from Technical Context** above:
+   - For each NEEDS CLARIFICATION → research task
+   - For each dependency → best practices task
+   - For each integration → patterns task
+
+2. **Generate and dispatch research agents**:
+
+   ```text
+   For each unknown in Technical Context:
+     Task: "Research {unknown} for {feature context}"
+   For each technology choice:
+     Task: "Find best practices for {tech} in {domain}"
+   ```
+
+3. **Consolidate findings** in `research.md` using format:
+   - Decision: [what was chosen]
+   - Rationale: [why chosen]
+   - Alternatives considered: [what else evaluated]
+
+**Output**: research.md with all NEEDS CLARIFICATION resolved
+
+### Phase 1: Design & Contracts
+
+**Prerequisites:** `research.md` complete
+
+1. **Extract entities from feature spec** → `data-model.md`:
+   - Entity name, fields, relationships
+   - Validation rules from requirements
+   - State transitions if applicable
+
+2. **Generate API contracts** from functional requirements:
+   - For each user action → endpoint
+   - Use standard REST/GraphQL patterns
+   - Output OpenAPI/GraphQL schema to `/contracts/`
+
+3. **Agent context update**:
+   - Run `.specify/scripts/bash/update-agent-context.sh claude`
+   - These scripts detect which AI agent is in use
+   - Update the appropriate agent-specific context file
+   - Add only new technology from current plan
+   - Preserve manual additions between markers
+
+**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+
+## Key rules
+
+- Use absolute paths
+- ERROR on gate failures or unresolved clarifications

--- a/.claude/agents/speckit-specify.md
+++ b/.claude/agents/speckit-specify.md
@@ -1,0 +1,225 @@
+---
+name: Speckit Specify
+description: Create or update the feature specification from a natural language feature description.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+The text the user typed after `/speckit.specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+
+Given that feature description, do this:
+
+1. **Generate a concise short name** (2-4 words) for the branch:
+   - Analyze the feature description and extract the most meaningful keywords
+   - Create a 2-4 word short name that captures the essence of the feature
+   - Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+   - Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+   - Keep it concise but descriptive enough to understand the feature at a glance
+   - Examples:
+     - "I want to add user authentication" → "user-auth"
+     - "Implement OAuth2 integration for the API" → "oauth2-api-integration"
+     - "Create a dashboard for analytics" → "analytics-dashboard"
+     - "Fix payment processing timeout bug" → "fix-payment-timeout"
+
+2. **Check for existing branches before creating new one**:
+
+   a. First, fetch all remote branches to ensure we have the latest information:
+
+      ```bash
+      git fetch --all --prune
+      ```
+
+   b. Find the highest feature number across all sources for the short-name:
+      - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'`
+      - Local branches: `git branch | grep -E '^[* ]*[0-9]+-<short-name>$'`
+      - Specs directories: Check for directories matching `specs/[0-9]+-<short-name>`
+
+   c. Determine the next available number:
+      - Extract all numbers from all three sources
+      - Find the highest number N
+      - Use N+1 for the new branch number
+
+   d. Run the script `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS"` with the calculated number and short-name:
+      - Pass `--number N+1` and `--short-name "your-short-name"` along with the feature description
+      - Bash example: `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" --json --number 5 --short-name "user-auth" "Add user authentication"`
+
+   **IMPORTANT**:
+   - Check all three sources (remote branches, local branches, specs directories) to find the highest number
+   - Only match branches/directories with the exact short-name pattern
+   - If no existing branches/directories found with this short-name, start with number 1
+   - You must only ever run this script once per feature
+   - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
+   - The JSON output will contain BRANCH_NAME and SPEC_FILE paths
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot")
+
+3. Load `.specify/templates/spec-template.md` to understand required sections.
+
+4. Follow this execution flow:
+
+    1. Parse user description from Input
+       If empty: ERROR "No feature description provided"
+    2. Extract key concepts from description
+       Identify: actors, actions, data, constraints
+    3. For unclear aspects:
+       - Make informed guesses based on context and industry standards
+       - Only mark with [NEEDS CLARIFICATION: specific question] if:
+         - The choice significantly impacts feature scope or user experience
+         - Multiple reasonable interpretations exist with different implications
+         - No reasonable default exists
+       - **LIMIT: Maximum 3 [NEEDS CLARIFICATION] markers total**
+       - Prioritize clarifications by impact: scope > security/privacy > user experience > technical details
+    4. Fill User Scenarios & Testing section
+       If no clear user flow: ERROR "Cannot determine user scenarios"
+    5. Generate Functional Requirements
+       Each requirement must be testable
+       Use reasonable defaults for unspecified details (document assumptions in Assumptions section)
+    6. Define Success Criteria
+       Create measurable, technology-agnostic outcomes
+       Include both quantitative metrics (time, performance, volume) and qualitative measures (user satisfaction, task completion)
+       Each criterion must be verifiable without implementation details
+    7. Identify Key Entities (if data involved)
+    8. Return: SUCCESS (spec ready for planning)
+
+5. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+
+6. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
+
+   a. **Create Spec Quality Checklist**: Generate a checklist file at `FEATURE_DIR/checklists/requirements.md` using the checklist template structure with these validation items:
+
+      ```markdown
+      # Specification Quality Checklist: [FEATURE NAME]
+      
+      **Purpose**: Validate specification completeness and quality before proceeding to planning
+      **Created**: [DATE]
+      **Feature**: [Link to spec.md]
+      
+      ## Content Quality
+      
+      - [ ] No implementation details (languages, frameworks, APIs)
+      - [ ] Focused on user value and business needs
+      - [ ] Written for non-technical stakeholders
+      - [ ] All mandatory sections completed
+      
+      ## Requirement Completeness
+      
+      - [ ] No [NEEDS CLARIFICATION] markers remain
+      - [ ] Requirements are testable and unambiguous
+      - [ ] Success criteria are measurable
+      - [ ] Success criteria are technology-agnostic (no implementation details)
+      - [ ] All acceptance scenarios are defined
+      - [ ] Edge cases are identified
+      - [ ] Scope is clearly bounded
+      - [ ] Dependencies and assumptions identified
+      
+      ## Feature Readiness
+      
+      - [ ] All functional requirements have clear acceptance criteria
+      - [ ] User scenarios cover primary flows
+      - [ ] Feature meets measurable outcomes defined in Success Criteria
+      - [ ] No implementation details leak into specification
+      
+      ## Notes
+      
+      - Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+      ```
+
+   b. **Run Validation Check**: Review the spec against each checklist item:
+      - For each item, determine if it passes or fails
+      - Document specific issues found (quote relevant spec sections)
+
+   c. **Handle Validation Results**:
+
+      - **If all items pass**: Mark checklist complete and proceed to step 6
+
+      - **If items fail (excluding [NEEDS CLARIFICATION])**:
+        1. List the failing items and specific issues
+        2. Update the spec to address each issue
+        3. Re-run validation until all items pass (max 3 iterations)
+        4. If still failing after 3 iterations, document remaining issues in checklist notes and warn user
+
+      - **If [NEEDS CLARIFICATION] markers remain**:
+        1. Extract all [NEEDS CLARIFICATION: ...] markers from the spec
+        2. **LIMIT CHECK**: If more than 3 markers exist, keep only the 3 most critical (by scope/security/UX impact) and make informed guesses for the rest
+        3. For each clarification needed (max 3), present options to user in this format:
+
+           ```markdown
+           ## Question [N]: [Topic]
+           
+           **Context**: [Quote relevant spec section]
+           
+           **What we need to know**: [Specific question from NEEDS CLARIFICATION marker]
+           
+           **Suggested Answers**:
+           
+           | Option | Answer | Implications |
+           |--------|--------|--------------|
+           | A      | [First suggested answer] | [What this means for the feature] |
+           | B      | [Second suggested answer] | [What this means for the feature] |
+           | C      | [Third suggested answer] | [What this means for the feature] |
+           | Custom | Provide your own answer | [Explain how to provide custom input] |
+           
+           **Your choice**: _[Wait for user response]_
+           ```
+
+        4. Number questions sequentially (Q1, Q2, Q3 - max 3 total)
+        5. Present all questions together before waiting for responses
+        6. Wait for user to respond with their choices for all questions
+        7. Update the spec by replacing each [NEEDS CLARIFICATION] marker with the user's selected or provided answer
+        8. Re-run validation after all clarifications are resolved
+
+   d. **Update Checklist**: After each validation iteration, update the checklist file with current pass/fail status
+
+7. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/speckit.clarify` or `/speckit.plan`).
+
+**NOTE:** The script creates and checks out the new branch and initializes the spec file before writing.
+
+## General Guidelines
+
+- Focus on **WHAT** users need and **WHY**.
+- Avoid HOW to implement (no tech stack, APIs, code structure).
+- Written for business stakeholders, not developers.
+- DO NOT create any checklists that are embedded in the spec. That will be a separate command.
+
+### Section Requirements
+
+- **Mandatory sections**: Must be completed for every feature
+- **Optional sections**: Include only when relevant to the feature
+- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### For AI Generation
+
+When creating this spec from a user prompt:
+
+1. **Make informed guesses**: Use context, industry standards, and common patterns to fill gaps
+2. **Document assumptions**: Record reasonable defaults in the Assumptions section
+3. **Limit clarifications**: Maximum 3 [NEEDS CLARIFICATION] markers - use only for critical decisions
+4. **Prioritize clarifications**: scope > security/privacy > user experience > technical details
+
+### Success Criteria Guidelines
+
+Success criteria must be:
+
+1. **Measurable**: Include specific metrics (time, percentage, count, rate)
+2. **Technology-agnostic**: No mention of frameworks, languages, databases, or tools
+3. **User-focused**: Describe outcomes from user/business perspective, not system internals
+4. **Verifiable**: Can be tested/validated without knowing implementation details
+
+**Good examples**:
+
+- "Users can complete checkout in under 3 minutes"
+- "System supports 10,000 concurrent users"
+- "95% of searches return results in under 1 second"
+
+**Bad examples** (implementation-focused):
+
+- "API response time is under 200ms"
+- "Database can handle 1000 TPS"
+- "React components render efficiently"

--- a/.claude/agents/speckit-tasks-to-issues.md
+++ b/.claude/agents/speckit-tasks-to-issues.md
@@ -1,0 +1,31 @@
+---
+name: Speckit Tasks to Issues
+description: Convert existing tasks into actionable, dependency-ordered GitHub issues for the feature based on available design artifacts.
+tools: [bash]
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. From the executed script, extract the path to **tasks**.
+1. Get the Git remote by running:
+
+```bash
+git config --get remote.origin.url
+```
+
+> [!CAUTION]
+> ONLY PROCEED TO NEXT STEPS IF THE REMOTE IS A GITHUB URL
+
+1. For each task in the list, use the GitHub MCP server to create a new issue in the repository that is representative of the Git remote.
+
+> [!CAUTION]
+> UNDER NO CIRCUMSTANCES EVER CREATE ISSUES IN REPOSITORIES THAT DO NOT MATCH THE REMOTE URL

--- a/.claude/agents/speckit-tasks.md
+++ b/.claude/agents/speckit-tasks.md
@@ -1,0 +1,129 @@
+---
+name: Speckit Tasks
+description: Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load design documents**: Read from FEATURE_DIR:
+   - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
+   - **Optional**: data-model.md (entities), contracts/ (API endpoints), research.md (decisions), quickstart.md (test scenarios)
+   - Note: Not all projects have all documents. Generate tasks based on what's available.
+
+3. **Execute task generation workflow**:
+   - Load plan.md and extract tech stack, libraries, project structure
+   - Load spec.md and extract user stories with their priorities (P1, P2, P3, etc.)
+   - If data-model.md exists: Extract entities and map to user stories
+   - If contracts/ exists: Map endpoints to user stories
+   - If research.md exists: Extract decisions for setup tasks
+   - Generate tasks organized by user story (see Task Generation Rules below)
+   - Generate dependency graph showing user story completion order
+   - Create parallel execution examples per user story
+   - Validate task completeness (each user story has all needed tasks, independently testable)
+
+4. **Generate tasks.md**: Use `.specify/templates/tasks-template.md` as structure, fill with:
+   - Correct feature name from plan.md
+   - Phase 1: Setup tasks (project initialization)
+   - Phase 2: Foundational tasks (blocking prerequisites for all user stories)
+   - Phase 3+: One phase per user story (in priority order from spec.md)
+   - Each phase includes: story goal, independent test criteria, tests (if requested), implementation tasks
+   - Final Phase: Polish & cross-cutting concerns
+   - All tasks must follow the strict checklist format (see Task Generation Rules below)
+   - Clear file paths for each task
+   - Dependencies section showing story completion order
+   - Parallel execution examples per story
+   - Implementation strategy section (MVP first, incremental delivery)
+
+5. **Report**: Output path to generated tasks.md and summary:
+   - Total task count
+   - Task count per user story
+   - Parallel opportunities identified
+   - Independent test criteria for each story
+   - Suggested MVP scope (typically just User Story 1)
+   - Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
+
+Context for task generation: $ARGUMENTS
+
+The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
+
+## Task Generation Rules
+
+**CRITICAL**: Tasks MUST be organized by user story to enable independent implementation and testing.
+
+**Tests are OPTIONAL**: Only generate test tasks if explicitly requested in the feature specification or if user requests TDD approach.
+
+### Checklist Format (REQUIRED)
+
+Every task MUST strictly follow this format:
+
+```text
+- [ ] [TaskID] [P?] [Story?] Description with file path
+```
+
+**Format Components**:
+
+1. **Checkbox**: ALWAYS start with `- [ ]` (markdown checkbox)
+2. **Task ID**: Sequential number (T001, T002, T003...) in execution order
+3. **[P] marker**: Include ONLY if task is parallelizable (different files, no dependencies on incomplete tasks)
+4. **[Story] label**: REQUIRED for user story phase tasks only
+   - Format: [US1], [US2], [US3], etc. (maps to user stories from spec.md)
+   - Setup phase: NO story label
+   - Foundational phase: NO story label  
+   - User Story phases: MUST have story label
+   - Polish phase: NO story label
+5. **Description**: Clear action with exact file path
+
+**Examples**:
+
+- ✅ CORRECT: `- [ ] T001 Create project structure per implementation plan`
+- ✅ CORRECT: `- [ ] T005 [P] Implement authentication middleware in src/middleware/auth.py`
+- ✅ CORRECT: `- [ ] T012 [P] [US1] Create User model in src/models/user.py`
+- ✅ CORRECT: `- [ ] T014 [US1] Implement UserService in src/services/user_service.py`
+- ❌ WRONG: `- [ ] Create User model` (missing ID and Story label)
+- ❌ WRONG: `T001 [US1] Create model` (missing checkbox)
+- ❌ WRONG: `- [ ] [US1] Create User model` (missing Task ID)
+- ❌ WRONG: `- [ ] T001 [US1] Create model` (missing file path)
+
+### Task Organization
+
+1. **From User Stories (spec.md)** - PRIMARY ORGANIZATION:
+   - Each user story (P1, P2, P3...) gets its own phase
+   - Map all related components to their story:
+     - Models needed for that story
+     - Services needed for that story
+     - Endpoints/UI needed for that story
+     - If tests requested: Tests specific to that story
+   - Mark story dependencies (most stories should be independent)
+
+2. **From Contracts**:
+   - Map each contract/endpoint → to the user story it serves
+   - If tests requested: Each contract → contract test task [P] before implementation in that story's phase
+
+3. **From Data Model**:
+   - Map each entity to the user story(ies) that need it
+   - If entity serves multiple stories: Put in earliest story or Setup phase
+   - Relationships → service layer tasks in appropriate story phase
+
+4. **From Setup/Infrastructure**:
+   - Shared infrastructure → Setup phase (Phase 1)
+   - Foundational/blocking tasks → Foundational phase (Phase 2)
+   - Story-specific setup → within that story's phase
+
+### Phase Structure
+
+- **Phase 1**: Setup (project initialization)
+- **Phase 2**: Foundational (blocking prerequisites - MUST complete before user stories)
+- **Phase 3+**: User Stories in priority order (P1, P2, P3...)
+  - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
+  - Each phase should be a complete, independently testable increment
+- **Final Phase**: Polish & Cross-Cutting Concerns

--- a/.claude/agents/user-experience-guidelines.md
+++ b/.claude/agents/user-experience-guidelines.md
@@ -1,0 +1,205 @@
+# User Experience Guidelines
+
+**Canonical Reference:** [CasePage](../../packages/client/src/pages/CasePage) implementation
+
+## 1. Sidebar Lists
+
+**Reference:** [CaseList.tsx](../../packages/client/src/components/CaseList/CaseList.tsx)
+
+### Required Elements
+- Create button at top: `navigate('/entity/new')`
+- Width: `lg:w-[200px]`
+- Active state: Compare `activeId` from `useParams()` with item id
+- Active styling: `bg-[#e8feff]`
+- Hover styling: `hover:bg-gray-100`
+- Truncate long text: `truncate` class
+- Include loading/error/empty states (see section 6)
+
+### Mobile
+- Hide on mobile: `hidden lg:block`
+- Show in Sheet overlay with `onCaseClick` callback to close
+
+---
+
+## 2. Inline Editing
+
+### Components
+- **Single-line text:** [EditableTitle](../../packages/client/src/components/common/EditableTitle/EditableTitle.tsx)
+- **Dropdowns:** [EditableSelect](../../packages/client/src/components/common/EditableSelect/EditableSelect.tsx)
+- **Multi-line text:** Custom with Textarea + Save/Cancel buttons
+
+### Usage
+```tsx
+// Title/heading
+<EditableTitle value={data.title} onSave={handleSave} isLoading={isPending} />
+
+// Dropdown - inline mode
+<EditableSelect value={data.field} options={OPTIONS} onChange={handleChange} />
+
+// Dropdown - always editing (for badges)
+<EditableSelect value={data.status} options={OPTIONS} onChange={handleChange} alwaysEditing />
+
+// Textarea
+{!editing ? <p onClick={() => setEditing(true)}>{text}</p> : <Textarea with Save/Cancel />}
+```
+
+### Mutation Pattern
+```tsx
+const mutation = trpc.entity.update.useMutation({
+  onMutate: async (variables) => {
+    await utils.entity.getById.cancel({ id });
+    const previous = utils.entity.getById.getData({ id });
+    if (previous) utils.entity.getById.setData({ id }, { ...previous, ...variables });
+    return { previous };
+  },
+  onSuccess: () => {
+    utils.entity.getById.invalidate({ id });
+    utils.entity.list.invalidate();
+  },
+  onError: (err, vars, context) => {
+    if (context?.previous) utils.entity.getById.setData({ id }, context.previous);
+  },
+});
+```
+
+---
+
+## 3. Delete with Confirmation
+
+**Reference:** [CaseInformation.tsx](../../packages/client/src/components/CaseDetails/components/CaseInformation/CaseInformation.tsx), [ConfirmationDialog.tsx](../../packages/client/src/components/common/ConfirmationDialog/ConfirmationDialog.tsx)
+
+### Pattern
+```tsx
+const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+const deleteEntity = trpc.entity.delete.useMutation({
+  onSuccess: () => {
+    utils.entity.list.invalidate();
+    navigate('/entities/');
+  },
+});
+
+// Trigger (usually in DropdownMenu)
+<DropdownMenuItem onClick={() => setIsDeleteDialogOpen(true)} className="text-red-600">
+  <Trash /> Delete Entity
+</DropdownMenuItem>
+
+// Dialog
+<ConfirmationDialog
+  open={isDeleteDialogOpen}
+  onOpenChange={setIsDeleteDialogOpen}
+  onConfirm={() => deleteEntity.mutate({ id })}
+  title="Delete Entity"
+  description="Are you sure? This cannot be undone."
+  confirmText="Delete"
+  confirmClassName="bg-red-600 hover:bg-red-700"
+  isLoading={deleteEntity.isPending}
+/>
+```
+
+---
+
+## 4. Create Form
+
+**Reference:** [CreateCasePage.tsx](../../packages/client/src/pages/CreateCasePage/CreateCasePage.tsx)
+
+### Routing
+- Route: `/entities/:id` where `id` can be `'new'`
+- Conditional render: `{id === 'new' ? <CreatePage /> : <DetailPage />}`
+- Create button: `onClick={() => navigate('/entities/new')}`
+
+### Form State
+```tsx
+const [field, setField] = useState('');
+const [validationErrors, setValidationErrors] = useState({});
+const [touched, setTouched] = useState(new Set());
+
+const createEntity = trpc.entity.create.useMutation({
+  onSuccess: (data) => {
+    utils.entity.list.invalidate();
+    navigate(`/entities/${data.id}`);
+  },
+});
+
+const handleSubmit = (e) => {
+  e.preventDefault();
+  setTouched(new Set(['field1', 'field2']));
+  if (!validate()) return;
+  createEntity.mutate({ field });
+};
+```
+
+### Validation
+- Track touched fields: `touched.has(fieldName)`
+- Show errors only for touched fields
+- Validate on blur and submit
+- Red border: `className={touched.has('field') && errors.field ? 'border-red-500' : ''}`
+
+---
+
+## 5. Responsive Design
+
+### Breakpoint
+- Mobile: default styles
+- Desktop: `lg:` prefix (>= 1024px)
+
+### Sidebar Pattern
+```tsx
+const [isSheetOpen, setIsSheetOpen] = useState(false);
+
+// Desktop sidebar
+<div className="hidden lg:block"><EntityList /></div>
+
+// Mobile sheet
+<Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
+  <EntityList onItemClick={() => setIsSheetOpen(false)} />
+</Sheet>
+
+// Menu button for mobile
+<Button onClick={() => setIsSheetOpen(true)} className="lg:hidden">
+  <List />
+</Button>
+```
+
+---
+
+## 6. States (Loading/Error/Empty)
+
+### Loading
+```tsx
+if (isLoading) return (
+  <Skeleton className="h-5 w-3/4" />
+  // Match final content shape
+);
+```
+
+### Error
+```tsx
+if (error) return (
+  <>
+    <p className="text-red-600">Error: {error.message}</p>
+    <Button onClick={() => refetch()}>Retry</Button>
+  </>
+);
+```
+
+### Empty
+```tsx
+if (!data || data.length === 0) return (
+  <p className="text-gray-500">No items found</p>
+);
+```
+
+---
+
+## Implementation Checklist
+
+- [ ] Sidebar list: 200px, create button, active states, mobile sheet
+- [ ] Inline editing: Use EditableTitle/EditableSelect components
+- [ ] Delete: ConfirmationDialog with red styling
+- [ ] Create: Form at `/entity/new` with validation and touched state
+- [ ] Optimistic updates: onMutate/onError rollback pattern
+- [ ] Responsive: Mobile sheet overlay, desktop always visible
+- [ ] States: Loading skeletons, error retry, empty messaging
+- [ ] Navigation: To list after delete, to detail after create
+- [ ] Cache: Invalidate list.invalidate() and getById.invalidate()

--- a/.claude/skills/component-reuse/SKILL.md
+++ b/.claude/skills/component-reuse/SKILL.md
@@ -1,0 +1,388 @@
+---
+name: component-reuse
+description: Ensure existing UI components are reused before creating new ones. Use when implementing any UI from Figma designs, tickets, or mockups. Requires a component audit to search the codebase before creating new components. If a component doesn't exist, delegates to figma-implement-component skill.
+---
+
+# Skill: Component Reuse
+
+Ensures existing components are discovered and reused before creating new ones to prevent duplicates and maintain design system consistency.
+
+## Required Before Creating Components
+
+Complete the audit process and output the audit table before creating any new component files.
+
+## When to Use
+
+- Before implementing UI elements from Figma designs
+- When tickets require adding UI components
+- Before creating any new component file
+
+## When Not to Use
+
+- For non-UI code (APIs, utilities, hooks)
+- When explicitly told to create new components regardless of existing ones
+
+## Key Principles
+
+1. Figma layer names ≠ actual component names
+2. Let Figma Code Connect reveal existing components - don't guess names
+3. Use existing components directly, avoid wrapper components
+4. CodeConnectSnippets indicate the component already exists in the codebase
+
+## Workflow
+
+```
+1. Extract all Figma URLs from Jira ticket
+2. Call get_design_context on each link
+3. If CodeConnects missing, use get_metadata to find nested instances
+4. Extract component names from CodeConnectSnippets
+5. Search exact names first (remove spaces)
+6. Search variations only if exact search fails
+7. Output audit table
+8. Reuse existing or delegate to figma-implement-component
+```
+
+## Step 0: Create Component Audit Todo List
+
+Use `manage_todo_list` to create a checklist before starting the audit.
+
+```javascript
+manage_todo_list({
+  todoList: [
+    {
+      id: 1,
+      title: 'Extract Figma links from ticket/request',
+      status: 'not-started'
+    },
+    {
+      id: 2,
+      title: 'Get design context for each Figma link',
+      status: 'not-started'
+    },
+    {
+      id: 3,
+      title: 'Check for nested components if needed',
+      status: 'not-started'
+    },
+    {
+      id: 4,
+      title: 'Extract component names from CodeConnectSnippets',
+      status: 'not-started'
+    },
+    {
+      id: 5,
+      title: 'Search exact component names',
+      status: 'not-started'
+    },
+    {
+      id: 6,
+      title: 'Search variations for unfound components',
+      status: 'not-started'
+    },
+    {
+      id: 7,
+      title: 'Output component audit table',
+      status: 'not-started'
+    },
+    {
+      id: 8,
+      title: 'Take action (REUSE/WRAP/CREATE)',
+      status: 'not-started'
+    }
+  ]
+})
+```
+
+Mark each task as `in-progress` before starting it, complete the work, then mark it `completed` immediately. Do not batch completion updates.
+
+## Step-by-Step Process
+
+### Step 1: Extract Figma Links
+
+When working from a Jira ticket, extract all Figma URLs:
+- Ticket description
+- Supporting Artifacts section
+- Comments or attachments
+
+Example format:
+```
+- https://www.figma.com/design/FILE_KEY?node-id=123-456 (Feature Button)
+- https://www.figma.com/design/FILE_KEY?node-id=789-012 (Feature Active)
+```
+
+### Step 2: Get Design Context for Each Link
+
+Call `mcp_figma_get_design_context` for every Figma URL:
+
+```javascript
+mcp_figma_get_design_context({ 
+  nodeId: "123-456",
+  clientFrameworks: "react",
+  clientLanguages: "typescript"
+})
+```
+
+Each screen may reference different components via Code Connect.
+
+**For nested components:** If get_design_context doesn't return expected CodeConnectSnippets, use `mcp_figma_get_metadata` on the same node to get the structure, find `<instance>` nodes, and call `get_design_context` on those instance IDs directly.
+
+### Step 3: Extract Component Names
+
+Look for CodeConnectSnippet elements in each response:
+
+```jsx
+<CodeConnectSnippet data-name="Feature Dialog">
+  <FeatureDialog open={true} onOpenChange={() => {}} />
+</CodeConnectSnippet>
+```
+
+Extract from each snippet:
+1. Component tag name (e.g., `FeatureDialog`) - most important
+2. The `data-name` attribute (e.g., "Feature Dialog")
+3. Any imports at the top
+
+Create a list of all unique component names found across all Figma links.
+
+### Step 4: Search Exact Names
+
+For every component found in CodeConnectSnippets, search using the exact name (remove spaces from data-name):
+
+- "Feature Dialog" → Search: `FeatureDialog`
+- "Feature Trigger" → Search: `FeatureTrigger`
+
+```bash
+grep_search "FeatureDialog" --includePattern="**/*.tsx"
+file_search "**/FeatureDialog/**"
+semantic_search "FeatureDialog component implementation"
+```
+
+### Step 5: Search Variations (Only if Exact Search Failed)
+
+If exact name search found nothing, try variations:
+
+- "Feature Dialog" → Try: `FeatureModal`, `Feature`, `Dialog`
+- "Feature Trigger" → Try: `FeatureButton`, `TriggerButton`
+
+Search common synonyms:
+- Trigger → Button, Toggle, Activator
+- Sheet → Dialog, Modal, Drawer, Panel
+- Dialog → Modal, Popup, Overlay
+
+```bash
+grep_search "Feature.*Button|Feature.*Trigger" --isRegexp=true --includePattern="**/*.tsx"
+semantic_search "feature trigger button component"
+```
+
+### Step 6: Output Audit Table
+
+Output this table before creating any components:
+```
+| Figma Screen | Figma Component | CodeConnect Name | Exact Search | Variation Search | Location | Action |
+|--------------|-----------------|------------------|--------------|------------------|----------|--------|
+| 123-456 | Feature Trigger | FeatureTrigger | NOT FOUND | Found as FeatureButton | common/FeatureButton/ | REUSE |
+| 789-012 | Feature Sheet | FeatureDialog | FOUND | N/A | common/FeatureDialog/ | WRAP |
+| 345-678 | Custom Widget | CustomWidget | NOT FOUND | NOT FOUND | NOT FOUND | CREATE |
+```
+
+Column definitions:
+- **Figma Screen**: Node ID from Figma URL
+- **Figma Component**: The `data-name` from CodeConnectSnippet
+- **CodeConnect Name**: Component tag (e.g., `<FeatureTrigger>`)
+- **Exact Search**: Did searching the CodeConnect name find anything?
+- **Variation Search**: What variation/synonym search succeeded?
+- **Location**: Path to existing component
+- **Action**: REUSE (use directly), WRAP (create domain wrapper), or CREATE (new component)
+
+**How to determine Action**:
+- **REUSE**: Component is domain-specific or already scoped (e.g., `CaseCard`, `CustomerForm`)
+- **WRAP**: Component is generic/common and needs domain logic (e.g., `FiltersDialog`, `ConfirmationDialog`)
+- **CREATE**: Component doesn't exist after exhaustive search
+
+### Step 7: Take Action
+
+For components marked REUSE:
+- Import and use the existing component directly
+- Adapt props as needed
+- No wrapper needed
+
+For components marked WRAP:
+- Create a domain-specific wrapper in the domain's `components/` folder
+- The wrapper encapsulates domain logic (hooks, state, data fetching)
+- The wrapper passes domain data to the generic component
+- Example: `FeatureGenericComponent` wraps `GenericComponent` + `useFeatureData()`
+- See "Domain Wrapper Components" in copilot-instructions.md for full pattern
+
+For components marked CREATE:
+- Answer these questions first:
+  1. What similar components did you find?
+  2. Why can't they be used or extended?
+  3. What specific functionality is missing?
+- If you cannot answer all three, reuse an existing component
+- Otherwise, invoke the `figma-implement-component` skill
+
+### Warning Signs to Stop
+
+Do not create components that:
+- Have generic names (Button, Input, Modal, Card, Alert, Dialog)
+- Serve common UI purposes (feedback, navigation, forms)
+- Look similar to something you've seen elsewhere
+
+Check existing components first. These almost certainly already exist.
+
+### What Not to Create
+
+| If Figma says... | Don't create... | Check for... |
+|------------------|-----------------|--------------|
+| Notification | Notification.tsx | Alert, Toast, Snackbar, Banner |
+| Popup | Popup.tsx | Dialog, Modal, Overlay, Sheet |
+| Input Field | InputField.tsx | Input, TextField, TextInput |
+| Action Button | ActionButton.tsx | Button (with variant prop) |
+
+## Integration with Other Skills
+
+This skill acts as a gate before implementation:
+```
+User Request → component-reuse (audit) → figma-implement-component (if CREATE) → Implementation
+```
+
+## Examples
+
+### Example 1: Feature Component Audit
+
+Step 1: Extract links from ticket
+```
+1. node-id=123-456 (Feature Button)
+2. node-id=789-012 (Feature Active)
+```
+
+Step 2: Get context for both links
+```javascript
+mcp_figma_get_design_context({ nodeId: "123-456" }) // No CodeConnect
+mcp_figma_get_design_context({ nodeId: "789-012" }) // Returns FeatureDialog
+```
+
+Step 3: Extract names
+```
+- FeatureDialog (from CodeConnect)
+- FeatureTrigger (from layer name)
+```
+
+Step 4: Search exact
+```
+FeatureDialog → FOUND at common/FeatureDialog/
+FeatureTrigger → NOT FOUND
+```
+
+Step 5: Search variations
+```
+FeatureButton → FOUND at common/FeatureButton/
+```
+
+Step 6: Audit table
+```
+| Screen | Component | CodeConnect | Exact | Variation | Location | Action |
+| 789-012 | Feature Panel | GenericDialog | FOUND | N/A | common/GenericDialog/ | WRAP |
+| 123-456 | Feature Trigger | FeatureTrigger | NOT FOUND | FeatureButton | common/FeatureButton/ | REUSE |
+```
+
+Step 7: 
+- For GenericDialog: Create FeatureGenericDialog wrapper in Feature domain
+- For FeatureButton: Import and use directly
+
+### Example 2: Component Already Exists
+
+Figma shows "Notification" → CodeConnect shows `<Alert variant="success" />`
+
+Search "Alert" → Found at obra/Alert/
+
+Action: REUSE Alert, don't create Notification
+
+### Example 3: Generic Component Needs Domain Wrapper
+
+Figma shows "Feature Panel" → CodeConnect shows `<GenericDialog />`
+
+Search "GenericDialog" → Found at common/GenericDialog/
+
+Analysis: GenericDialog is generic (accepts any data/config), but FeatureName needs specific:
+- Domain-specific data sources
+- Custom validation logic
+- useFeatureData hook for state management
+
+Action: WRAP
+- Create FeatureGenericDialog in FeatureName/components/
+- Use useFeatureData hook
+- Pass data to GenericDialog
+
+Result:
+```tsx
+// FeatureName/components/FeatureGenericDialog/FeatureGenericDialog.tsx
+export function FeatureGenericDialog({ open, onOpenChange }) {
+  const { data, handleAction, handleClear } = useFeatureData();
+  return (
+    <GenericDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      data={data}
+      onAction={handleAction}
+      onClear={handleClear}
+    />
+  );
+}
+```
+
+### Example 4: Component Missing
+
+Figma shows "Custom Component" → No CodeConnect
+
+Search "CustomComponent" → NOT FOUND
+Search "Custom", "Component" → NOT FOUND
+
+Action: Create via figma-implement-component skill
+
+## Common Mistakes
+
+### Not checking Figma first
+Incorrect: See "feature" mentioned → Create FeatureButton
+Correct: Extract Figma links → Call get_design_context → Check CodeConnect → Search exact names
+
+### Calling get_design_context on only one link
+Incorrect: Ticket has 3 links → Check first one only
+Correct: Call get_design_context on all 3 links
+
+### Searching variations before exact names
+Incorrect: CodeConnect shows "FeatureTrigger" → Search "feature button badge"
+Correct: Search exact "FeatureTrigger" first → Then try variations
+
+### Creating before auditing
+Incorrect: Need feature button → Create FeatureButton.tsx
+Correct: Run audit → Output table → Confirm missing → Then create
+
+### Ignoring CodeConnectSnippets
+Incorrect: See `<FeatureDialog />` in CodeConnect → Create new FeatureDialog
+Correct: CodeConnect presence means it exists → Search for it → Reuse it
+
+### Searching only one term
+Incorrect: Search "FeatureDialog" → Not found → Create it
+Correct: Search "FeatureDialog" → "FeatureModal" → "Dialog" → Semantic search → Then decide
+
+## Quality Checklist
+
+Before proceeding to implementation:
+
+- [ ] Extracted all Figma links from ticket
+- [ ] Called get_design_context on every link
+- [ ] Identified all CodeConnectSnippets
+- [ ] Searched exact names first
+- [ ] Searched variations only after exact search failed
+- [ ] Output the audit table
+- [ ] For REUSE: Verified component meets requirements
+- [ ] For CREATE: Confirmed exhaustive search found nothing
+- [ ] No duplicates: Not creating what exists with different name from ticket
+- [ ] Called get_design_context on every link
+- [ ] Identified all CodeConnectSnippets
+- [ ] Searched exact names first
+- [ ] Searched variations only after exact search failed
+- [ ] Output the audit table
+- [ ] For REUSE: Verified component meets requirements
+- [ ] For CREATE: Confirmed exhaustive search found nothing
+- [ ] No duplicates: Not creating what exists with different name

--- a/.claude/skills/create-react-modlet/SKILL.md
+++ b/.claude/skills/create-react-modlet/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: create-react-modlet
+description: Create React components, hooks, or utilities following the modlet pattern. Use when creating any component in packages/client/src/components/. Modlets are self-contained folders with index.ts, implementation, tests, stories (for visual), and optional types.
+---
+
+# Skill: Creating React Modlets
+
+This skill teaches how to create React components, hooks, and utilities following the **modlet pattern** in this project.
+
+## What Is a Modlet?
+
+A modlet is a self-contained folder that houses everything related to a specific module. Each modlet includes its implementation, tests, stories (for visual components), and types—all in one place.
+
+## When to Use This Skill
+
+Use this skill when:
+- Creating any new React component
+- Creating a custom hook
+- Creating a utility/helper function
+- Breaking down a complex component into sub-components
+
+## Modlet Locations
+
+Components are organized in `packages/client/src/components/`:
+
+```
+packages/client/src/components/
+├── ui/              # Shadcn UI components (DO NOT modify manually)
+├── common/          # Shared reusable components
+├── inline-edit/     # Inline editing components (grouping folder)
+├── Header/          # Feature component
+├── CaseList/        # Feature component
+├── CaseDetails/     # Feature component
+└── MenuList/        # Feature component
+```
+
+## Naming Conventions
+
+- **PascalCase** for component folders: `EditableTitle/`, `Header/`, `Button/`
+- **kebab-case** for grouping folders: `inline-edit/`, `common/`
+- **lowercase** for standard folders: `components/`, `hooks/`, `helpers/`
+
+## Modlet Types
+
+### Visual Modlet (React Component)
+
+```
+ComponentName/
+├── index.ts                    # Re-export entry point (required)
+├── ComponentName.tsx           # Component implementation (required)
+├── ComponentName.test.tsx      # Tests (required)
+├── ComponentName.stories.tsx   # Storybook story (required)
+└── types.ts                    # Custom types (optional)
+```
+
+### Non-Visual Modlet (Hook/Utility)
+
+```
+useMyHook/
+├── index.ts                    # Re-export entry point (required)
+├── useMyHook.ts                # Implementation (required)
+├── useMyHook.test.ts           # Tests (required)
+└── types.ts                    # Custom types (optional)
+```
+
+## Core Rules
+
+1. **Folder naming**: Name the modlet folder after its main export (e.g., `/Button` exports `Button`)
+2. **index.ts only re-exports**: Never define logic in `index.ts`, only re-export from within the modlet
+3. **Tests are mandatory**: Every modlet must have tests in `<modlet-name>.test.tsx`
+4. **Stories for visual modlets**: All visual components must have Storybook stories
+5. **Sub-organization**: Additional components go in `/components` subfolder, hooks in `/hooks`, helpers in `/helpers` - each as its own modlet
+
+## Creation Process
+
+### Step 1: Plan with Todos
+
+Use `manage_todo_list` to track progress:
+
+```
+1. Create modlet folder
+2. Add index.ts with re-exports
+3. Add main component/hook file
+4. Add test file
+5. (Visual) Add story file
+6. (If needed) Add types.ts
+7. Verify tests pass
+8. Verify TypeScript compiles
+9. (Visual) Verify story renders
+```
+
+### Step 2: Create Files
+
+#### index.ts (Required)
+
+```typescript
+export { ComponentName } from './ComponentName';
+export type { ComponentNameProps } from './types';
+```
+
+#### ComponentName.tsx (Required)
+
+```tsx
+import { cn } from '@/lib/utils';
+import type { ComponentNameProps } from './types';
+
+export function ComponentName({ className, ...props }: ComponentNameProps) {
+  return (
+    <div className={cn('component-styles', className)}>
+      {/* Implementation */}
+    </div>
+  );
+}
+```
+
+#### ComponentName.test.tsx (Required)
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ComponentName } from './ComponentName';
+
+describe('ComponentName', () => {
+  it('should render correctly', () => {
+    render(<ComponentName />);
+    expect(screen.getByText('expected text')).toBeInTheDocument();
+  });
+
+  it('should handle user interaction', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(<ComponentName onClick={handleClick} />);
+    
+    await user.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalled();
+  });
+});
+```
+
+#### ComponentName.stories.tsx (Required for Visual)
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { ComponentName } from './ComponentName';
+
+const meta: Meta<typeof ComponentName> = {
+  component: ComponentName,
+  title: 'Common/ComponentName',  // Use: Common/, InlineEdit/, Feature name, etc.
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ComponentName>;
+
+export const Default: Story = {
+  args: {
+    // Default props
+  },
+};
+
+export const Variant: Story = {
+  args: {
+    // Variant props
+  },
+};
+```
+
+#### types.ts (Optional)
+
+```typescript
+export interface ComponentNameProps {
+  /** Additional CSS classes */
+  className?: string;
+  // Other props
+}
+
+export type ComponentNameVariant = 'primary' | 'secondary';
+```
+
+### Step 3: Verify
+
+Run these commands from the project root:
+
+```bash
+# Run tests
+npm run test
+
+# Type check
+npm run typecheck
+
+# Start Storybook (for visual verification)
+npm run storybook
+```
+
+## Project-Specific Patterns
+
+### Import Aliases
+
+Use the `@/` alias for imports:
+
+```tsx
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { SomeComponent } from '@/components/common/SomeComponent';
+```
+
+### Shadcn UI Components
+
+Reuse components from `@/components/ui/`:
+
+```tsx
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardHeader, CardContent } from '@/components/ui/card';
+```
+
+### Tailwind CSS
+
+Use Tailwind classes for styling. Use `cn()` for conditional classes:
+
+```tsx
+import { cn } from '@/lib/utils';
+
+<div className={cn('base-classes', isActive && 'active-classes', className)} />
+```
+
+### Story Decorators
+
+When components need context providers:
+
+```tsx
+import { BrowserRouter } from 'react-router-dom';
+
+const meta: Meta<typeof ComponentName> = {
+  component: ComponentName,
+  decorators: [
+    (Story) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+};
+```
+
+## Sub-Modlet Organization
+
+For complex components with internal sub-components:
+
+```
+ComplexComponent/
+├── index.ts
+├── ComplexComponent.tsx
+├── ComplexComponent.test.tsx
+├── ComplexComponent.stories.tsx
+├── types.ts
+├── components/
+│   ├── SubComponentA/
+│   │   ├── index.ts
+│   │   ├── SubComponentA.tsx
+│   │   └── SubComponentA.test.tsx
+│   └── SubComponentB/
+│       ├── index.ts
+│       ├── SubComponentB.tsx
+│       └── SubComponentB.test.tsx
+└── hooks/
+    └── useComponentLogic/
+        ├── index.ts
+        ├── useComponentLogic.ts
+        └── useComponentLogic.test.ts
+```
+
+## Quality Checklist
+
+Before completing any modlet:
+
+- [ ] Folder name matches main export
+- [ ] `index.ts` exists and only contains re-exports
+- [ ] Main module file exists
+- [ ] Test file exists and passes (`npm run test`)
+- [ ] (Visual only) Story file exists
+- [ ] Types file exists if custom types are defined
+- [ ] Sub-folders follow modlet structure
+- [ ] `npm run typecheck` passes
+- [ ] Modlet can be imported from its `index.ts`
+
+## Common Mistakes to Avoid
+
+- ❌ Missing `index.ts` file
+- ❌ Defining logic directly in `index.ts` instead of re-exporting
+- ❌ Skipping tests
+- ❌ Missing Storybook stories for visual components
+- ❌ Not verifying tests pass after creation
+- ❌ Folder name doesn't match main export name
+
+## Existing Examples
+
+Reference these existing modlets for patterns:
+
+**Full modlet with types:**
+- `components/Header/` - Has index.ts, component, test, story, types
+
+**Modlet in grouping folder:**
+- `components/inline-edit/EditableText/` - Inline edit component
+
+**Common component:**
+- `components/common/ConfirmationDialog/` - Dialog component in common folder
+
+## Testing Notes
+
+This project uses:
+- **Vitest** for test runner
+- **@testing-library/react** for component testing
+- **@testing-library/user-event** for user interaction testing
+- **@testing-library/jest-dom** for DOM matchers
+
+Tests are configured via `vitest.config.ts` with jsdom environment.

--- a/.claude/skills/create-skill/SKILL.md
+++ b/.claude/skills/create-skill/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: create-skill
+description: Create new Agent Skills for this project. Use when asked to create a skill, document a workflow, or teach Claude a new capability. Skills are stored in .claude/skills/ and can include instructions, scripts, examples, and resources.
+---
+
+# Skill: Creating Agent Skills
+
+This skill teaches how to create Agent Skills for this project following the VS Code Agent Skills standard.
+
+## What Are Agent Skills?
+
+Agent Skills are folders of instructions, scripts, and resources that AI agents (Copilot, Claude, etc.) can load when relevant to perform specialized tasks. They are:
+
+- **Portable**: Work across VS Code, Copilot CLI, and GitHub Copilot coding agent
+- **On-demand**: Only loaded when relevant to the current task
+- **Composable**: Multiple skills can work together
+- **Resource-rich**: Can include scripts, examples, templates, and documentation
+
+## When to Create a Skill
+
+Create a skill when you need to:
+- Document a repeatable workflow or process
+- Teach domain-specific knowledge that applies to multiple tasks
+- Provide scripts, templates, or examples for common operations
+- Define specialized capabilities that go beyond coding standards
+
+**Don't create a skill** when you just need:
+- Coding standards or style guidelines → Use custom instructions instead
+- One-time documentation → Use regular markdown files
+- File-specific rules → Use glob-based instructions
+
+## Skill Directory Structure
+
+```
+.claude/skills/
+└── your-skill-name/
+    ├── SKILL.md           # Required: Skill definition
+    ├── script.sh          # Optional: Helper scripts
+    ├── template.ts        # Optional: Code templates
+    └── examples/          # Optional: Example files
+        └── example-1.md
+```
+
+## SKILL.md Format
+
+Every skill must have a `SKILL.md` file with YAML frontmatter:
+
+```markdown
+---
+name: skill-name
+description: Clear description of what the skill does and when to use it
+---
+
+# Skill Title
+
+Detailed instructions, guidelines, and examples...
+```
+
+### Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique identifier, lowercase with hyphens (max 64 chars) |
+| `description` | Yes | What it does and when to use it (max 1024 chars) |
+
+### Writing Effective Descriptions
+
+The description determines when Copilot loads your skill. Be specific about:
+- **What** the skill accomplishes
+- **When** it should be used (triggers)
+- **What kind of tasks** it helps with
+
+**Good description:**
+```yaml
+description: Create and configure tRPC routers with proper type inference, input validation using Zod schemas, and error handling. Use when adding new API endpoints, creating CRUD operations, or setting up tRPC procedures.
+```
+
+**Bad description:**
+```yaml
+description: Helps with tRPC stuff.
+```
+
+### Body Content Guidelines
+
+The body should include:
+
+1. **Overview**: What the skill accomplishes
+2. **When to Use**: Clear triggers for activation
+3. **Step-by-Step Instructions**: Detailed procedures
+4. **Examples**: Input/output examples with code
+5. **Common Mistakes**: What to avoid
+6. **Resource References**: Links to included files
+
+### Referencing Resources
+
+Reference files in the skill directory using relative paths:
+
+```markdown
+Use the [test template](./test-template.ts) as a starting point.
+
+See [examples](./examples/) for common patterns.
+
+Run the [setup script](./setup.sh) to initialize the environment.
+```
+
+## Skill Loading Process
+
+Skills use progressive disclosure for efficiency:
+
+1. **Discovery**: Agent reads `name` and `description` from frontmatter
+2. **Loading**: When relevant, agent loads the full `SKILL.md` body
+3. **Resources**: Additional files load only when explicitly referenced
+
+This means you can have many skills without bloating context.
+
+## Example Skills
+
+### Simple Instruction Skill
+
+```markdown
+---
+name: component-testing
+description: Test React components using Vitest and Testing Library. Use when writing component tests, setting up test utilities, or debugging test failures.
+---
+
+# Component Testing
+
+## Testing Stack
+- Vitest for test runner
+- @testing-library/react for component rendering
+- @testing-library/user-event for interactions
+- MSW for API mocking
+
+## Test File Location
+Place tests next to components: `ComponentName.test.tsx`
+
+## Basic Test Structure
+\`\`\`typescript
+import { render, screen } from '@testing-library/react';
+import { ComponentName } from './ComponentName';
+
+describe('ComponentName', () => {
+  it('renders correctly', () => {
+    render(<ComponentName />);
+    expect(screen.getByText('Expected Text')).toBeInTheDocument();
+  });
+});
+\`\`\`
+```
+
+### Skill with Scripts and Templates
+
+```
+.claude/skills/database-migration/
+├── SKILL.md
+├── migration-template.sql
+└── validate-migration.sh
+```
+
+```markdown
+---
+name: database-migration
+description: Create and apply Prisma database migrations safely. Use when changing the schema, adding new models, or modifying existing tables.
+---
+
+# Database Migration
+
+## Before Making Changes
+1. Check current migration status: `npm run db:status`
+2. Create a backup if needed
+
+## Creating a Migration
+Use the [migration template](./migration-template.sql) for complex changes.
+
+## Validation
+Run [validate-migration.sh](./validate-migration.sh) to check for:
+- Breaking changes
+- Data loss risks
+- Index recommendations
+```
+
+## Skills in This Project
+
+Current skills are located in `.claude/skills/`:
+
+| Skill | Purpose |
+|-------|---------|
+| `cross-package-types` | Type flow between shared, server, and client packages |
+| `create-skill` | This skill - how to create new skills |
+
+## Best Practices
+
+### Do
+- Write clear, specific descriptions that trigger on relevant prompts
+- Include concrete examples with code
+- Reference external files for large templates or scripts
+- Document common mistakes and how to avoid them
+- Keep instructions actionable and step-by-step
+
+### Don't
+- Make descriptions too vague or too broad
+- Duplicate content already in custom instructions
+- Include huge code blocks (use external files instead)
+- Forget to document when NOT to use the skill
+- Create skills for one-off tasks
+
+## Adding a New Skill to This Project
+
+1. Create directory: `.claude/skills/your-skill-name/`
+2. Create `SKILL.md` with frontmatter and instructions
+3. Add any supporting files (scripts, templates, examples)
+4. Test by asking Copilot a question the skill should handle
+5. Verify the skill was loaded (check if instructions were followed)
+
+## Related Resources
+
+- [VS Code Agent Skills Documentation](https://code.visualstudio.com/docs/copilot/customization/agent-skills)
+- [Agent Skills Standard](https://agentskills.io/)
+- [Reference Skills Repository](https://github.com/anthropics/skills)
+- [Awesome Copilot Collection](https://github.com/github/awesome-copilot)

--- a/.claude/skills/cross-package-types/SKILL.md
+++ b/.claude/skills/cross-package-types/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: cross-package-types
+description: Manage TypeScript type flow between @carton/shared, @carton/server, and @carton/client packages. Use when adding Prisma models, creating tRPC procedures, importing types in components, or resolving circular dependency issues between packages.
+---
+
+# Cross-Package Type Flow
+
+This skill defines how TypeScript types flow between the three packages in this monorepo:
+- `@carton/shared` - Prisma schema, generated types, browser-safe utilities
+- `@carton/server` - tRPC router, API definitions, database operations
+- `@carton/client` - React frontend, UI components
+
+## Core Philosophy: Always Derive, Never Manually Define
+
+**CRITICAL**: Types flow in one direction: `Prisma → Zod → tRPC → Client`
+
+Every type in this codebase should be traceable back to the Prisma schema. This ensures:
+- Single source of truth for data models
+- Automatic type safety through the entire stack
+- No manual type synchronization required
+
+## Type Flow Architecture
+
+```mermaid
+flowchart TB
+    subgraph shared["@carton/shared"]
+        schema["prisma/schema<br/>(Prisma models)"]
+        generated["generated/<br/>(Zod schemas)"]
+        clientTs["client.ts<br/>(browser-safe)"]
+        prismaTs["prisma.ts<br/>(PrismaClient)"]
+        typesShared["types.ts<br/>(derived types)"]
+        
+        schema --> generated
+        generated --> clientTs
+        schema --> prismaTs
+        generated --> typesShared
+    end
+    
+    subgraph server["@carton/server"]
+        context["context.ts<br/>(Prisma ctx)"]
+        router["router.ts<br/>(AppRouter)"]
+        indexTs["index.ts<br/>exports: AppRouter"]
+        
+        context --> router
+        router --> indexTs
+    end
+    
+    subgraph client["@carton/client"]
+        components["components/<br/>(imports from shared/client)"]
+        trpc["trpc.tsx<br/>(typed client)"]
+        typesClient["types.ts<br/>(inferred from AppRouter)"]
+        
+        components --> trpc
+        trpc --> typesClient
+    end
+    
+    prismaTs --> context
+    typesShared --> router
+    clientTs --> components
+    indexTs -.->|"type-only"| trpc
+```
+
+## Key Principles
+
+### 1. Prisma is the Single Source of Truth
+- All data models are defined in `packages/shared/prisma/schema.prisma`
+- Run `npm run db:generate` to create Prisma Client and Zod schemas
+- **NEVER** manually define types that duplicate Prisma models
+
+### 2. Schema Derivation Pattern
+Always derive API schemas from generated base schemas using Zod methods:
+- `.pick({...})` - Select specific fields
+- `.omit({...})` - Remove specific fields
+- `.extend({...})` - Add new fields
+- `.partial()` - Make all fields optional
+
+### 3. PRISMA_AUTO_FIELDS Helper
+For create/update operations, use a helper to omit auto-generated fields:
+
+```typescript
+// packages/shared/src/helpers.ts
+export const PRISMA_AUTO_FIELDS = {
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+```
+
+### 4. Two Entry Points for Shared Package
+- `@carton/shared` - Full exports including Prisma (server-only)
+- `@carton/shared/client` - Browser-safe exports (no Prisma runtime)
+
+### 5. AppRouter Types Flow from Server
+- `AppRouter` type is defined in `@carton/server`
+- Client imports `AppRouter` directly from server (type-only import)
+- Use `inferRouterOutputs<AppRouter>` for API response types
+
+### 6. No Circular Dependencies
+- shared → (nothing)
+- server → shared
+- client → shared/client, server (type-only)
+
+## Schema Derivation Examples
+
+### Creating Input Schemas (Server)
+
+```typescript
+// packages/server/src/router.ts
+import { CaseSchema, PRISMA_AUTO_FIELDS } from '@carton/shared';
+
+// For creating a new case - omit auto-generated fields
+const CaseCreateInputSchema = CaseSchema.omit({
+  ...PRISMA_AUTO_FIELDS,
+  caseNumber: true, // auto-generated on server
+});
+
+// For updating a case - partial fields, excluding id
+const CaseUpdateInputSchema = CaseSchema.omit({
+  ...PRISMA_AUTO_FIELDS,
+}).partial();
+
+// For queries with specific fields
+const CaseListQuerySchema = CaseSchema.pick({
+  status: true,
+  priority: true,
+}).partial();
+```
+
+### Form Schemas (Client)
+
+```typescript
+// packages/client/src/pages/CreateCasePage/schema.ts
+import { CaseCreateInputSchema } from '@carton/shared/client';
+
+// Form schema derived from API schema
+export const CaseFormSchema = CaseCreateInputSchema.pick({
+  title: true,
+  description: true,
+  priority: true,
+});
+
+export type CaseFormData = z.infer<typeof CaseFormSchema>;
+```
+
+### Extending Schemas
+
+```typescript
+// Adding validation to a derived schema
+const CaseCreateWithValidationSchema = CaseSchema.omit({
+  ...PRISMA_AUTO_FIELDS,
+}).extend({
+  title: z.string().min(3, 'Title must be at least 3 characters'),
+  description: z.string().max(1000, 'Description too long'),
+});
+```
+
+## Import Patterns
+
+### Server Importing from Shared
+```typescript
+// packages/server/src/router.ts
+import {
+  CaseSchema,
+  CaseStatusSchema,
+  PRISMA_AUTO_FIELDS,
+  prisma
+} from '@carton/shared';
+```
+
+### Client Importing Browser-Safe Code from Shared
+```typescript
+// packages/client/src/components/SomeComponent.tsx
+import {
+  formatCaseNumber,
+  CASE_STATUS_OPTIONS,
+  CaseStatusSchema
+} from '@carton/shared/client';
+```
+
+### Client Importing Types from Server
+```typescript
+// packages/client/src/components/CaseList/types.ts
+import type { inferRouterOutputs } from '@trpc/server';
+import type { AppRouter } from '@carton/server';
+
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+export type CaseListItem = RouterOutputs['case']['list'][number];
+```
+
+### Client Creating tRPC Client
+```typescript
+// packages/client/src/lib/trpc.tsx
+import { createTRPCReact } from '@trpc/react-query';
+import type { AppRouter } from '@carton/server';
+
+export const trpc = createTRPCReact<AppRouter>();
+```
+
+## Adding New Features
+
+### When Adding a New Prisma Model
+
+1. **Define in shared**: Add model to `packages/shared/prisma/schema.prisma`
+2. **Generate types**: Run `npm run db:generate`
+3. **Create derived schemas**: Use `.pick()`, `.omit()`, `.extend()` for API inputs
+4. **Create router**: Add tRPC procedures in `packages/server/src/router.ts`
+5. **Use in client**: Import `AppRouter` from server for type inference
+
+### When Creating API Input Schemas
+
+1. **Start with generated schema**: Import the base schema from `@carton/shared`
+2. **Derive using Zod methods**: Use `.omit()` for create, `.partial()` for update
+3. **Use PRISMA_AUTO_FIELDS**: Omit id/createdAt/updatedAt for inputs
+4. **Add validation**: Use `.extend()` for custom validation rules
+
+### When Adding Form Validation
+
+1. **Import from shared/client**: Use browser-safe exports
+2. **Derive from API schema**: Use `.pick()` to select form fields
+3. **Add UI validation**: Use `.extend()` for client-specific rules
+4. **Keep in sync**: Forms validate what API expects
+
+## Common Mistakes to Avoid
+
+### ❌ Don't: Manually define types that duplicate Prisma
+```typescript
+// WRONG - will get out of sync with Prisma schema
+type CaseStatus = 'TO_DO' | 'IN_PROGRESS' | 'COMPLETED' | 'CLOSED';
+
+interface Case {
+  id: string;
+  title: string;
+  status: CaseStatus;
+}
+```
+
+### ✅ Do: Import from generated schemas
+```typescript
+// CORRECT - auto-generated from Prisma
+import { CaseSchema, CaseStatusSchema } from '@carton/shared';
+import type { Case, CaseStatus } from '@carton/shared';
+```
+
+### ❌ Don't: Create input schemas from scratch
+```typescript
+// WRONG - duplicates Prisma schema fields
+const CreateCaseInput = z.object({
+  title: z.string(),
+  description: z.string().optional(),
+  status: z.enum(['TO_DO', 'IN_PROGRESS', 'COMPLETED', 'CLOSED']),
+  priority: z.enum(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']),
+});
+```
+
+### ✅ Do: Derive input schemas from base schemas
+```typescript
+// CORRECT - derived from generated schema
+import { CaseSchema, PRISMA_AUTO_FIELDS } from '@carton/shared';
+
+const CreateCaseInput = CaseSchema.omit({
+  ...PRISMA_AUTO_FIELDS,
+  caseNumber: true,
+});
+```
+
+### ❌ Don't: Import Prisma in client code
+```typescript
+// WRONG - will break browser builds
+import { prisma } from '@carton/shared';
+```
+
+### ✅ Do: Use the client entry point
+```typescript
+// CORRECT - browser-safe
+import { formatCaseNumber, CaseStatusSchema } from '@carton/shared/client';
+```
+
+### ❌ Don't: Create circular dependencies
+```typescript
+// WRONG - shared importing from server
+// packages/shared/src/types.ts
+import type { AppRouter } from '@carton/server'; // CIRCULAR!
+```
+
+### ✅ Do: Import AppRouter in client only
+```typescript
+// CORRECT - client imports from server (type-only)
+// packages/client/src/lib/trpc.tsx
+import type { AppRouter } from '@carton/server';
+```
+
+## Type Inference Pattern
+
+The recommended pattern for component types:
+
+```typescript
+// packages/client/src/components/CaseList/types.ts
+import type { inferRouterOutputs } from '@trpc/server';
+import type { AppRouter } from '@carton/server';
+
+// Infer all router outputs
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+
+// Create specific types for this component
+export type CaseListItem = RouterOutputs['case']['list'][number];
+export type CaseDetail = RouterOutputs['case']['getById'];
+
+// Props interface using inferred types
+export interface CaseListProps {
+  cases?: CaseListItem[];
+  onCaseSelect?: (caseItem: CaseListItem) => void;
+}
+```
+
+This ensures types always match what the API actually returns, including proper Date → string serialization.
+
+## Type Derivation Summary
+
+| Need | Method | Example |
+|------|--------|---------|
+| Create input | `.omit({ ...PRISMA_AUTO_FIELDS })` | Remove id, createdAt, updatedAt |
+| Update input | `.omit({ ...PRISMA_AUTO_FIELDS }).partial()` | All fields optional except auto-fields |
+| Query params | `.pick({ field1, field2 }).partial()` | Select specific filterable fields |
+| Form data | `CreateInput.pick({ field1, field2 })` | Subset of create input for forms |
+| Response type | `inferRouterOutputs<AppRouter>['route']['method']` | Infer from tRPC router |
+| Extend validation | `.extend({ field: z.string().min(3) })` | Add custom validation rules |

--- a/.claude/skills/figma-component-sync/SKILL.md
+++ b/.claude/skills/figma-component-sync/SKILL.md
@@ -1,0 +1,331 @@
+---
+name: figma-component-sync
+description: Check a React component against its Figma design source and identify differences. Use when reviewing component implementations, syncing designs, auditing visual accuracy, or updating components to match new Figma designs.
+---
+
+# Skill: Figma Component Sync
+
+This skill checks a component's implementation against its Figma design source and helps you decide which differences to accept, ignore, or implement.
+
+## When to Use
+
+- Reviewing if a component matches its Figma design
+- Auditing visual accuracy of existing components
+- Updating components after Figma design changes
+- Documenting known/accepted design deviations
+
+## Prerequisites
+
+- Component must have a `README.md` with a Figma link in the format:
+  ```markdown
+  ## Figma Source
+  https://www.figma.com/design/{fileKey}/{fileName}?node-id={nodeId}&m=dev
+  ```
+- Figma MCP must be configured and authenticated
+
+## Workflow Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 1. FETCH - Get Figma design context and current component code  │
+├─────────────────────────────────────────────────────────────────┤
+│ 2. TRACE DEPENDENCIES - Identify internal components used       │
+├─────────────────────────────────────────────────────────────────┤
+│ 3. ANALYZE - Compare design vs implementation (all files)       │
+├─────────────────────────────────────────────────────────────────┤
+│ 4. REVIEW - User decides: implement, ignore, or accept each     │
+├─────────────────────────────────────────────────────────────────┤
+│ 5. APPLY - Implement approved changes                           │
+├─────────────────────────────────────────────────────────────────┤
+│ 6. TEST - Verify implementation matches Figma                   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Step-by-Step Instructions
+
+### Step 1: Initialize Check
+
+Given a component path (e.g., `packages/client/src/components/inline-edit/EditableText`):
+
+1. **Create output directory**:
+   ```
+   .temp/component-updates/{component-name}/
+   ```
+
+2. **Find and read the component's README.md** to extract Figma link
+
+3. **Check parent folder** for additional README.md with relevant Figma context
+
+4. **Fetch Figma design context** using `mcp_figma_get_design_context`:
+   - Extract `fileKey` and `nodeId` from the Figma URL
+   - Call the MCP tool with those parameters
+   - Save output to `.temp/component-updates/{component-name}/figma-context.md`
+
+5. **Read current component implementation**:
+   - Main component file (`.tsx`)
+   - Styles if separate
+   - Save analysis to `.temp/component-updates/{component-name}/current-implementation.md`
+
+### Step 2: Trace Dependencies
+
+Identify internal components that may implement Figma-specified styles:
+
+1. **Parse imports** from the main component file:
+   - Look for imports from relative paths (e.g., `../BaseEditable`, `../EditControls`)
+   - Ignore external packages (`react`, `lucide-react`, `@/components/ui/*`)
+
+2. **For each internal dependency**:
+   - Read the component's source code
+   - Check if it has its own README.md with Figma source
+   - If yes, fetch that Figma context too
+
+3. **Map Figma properties to responsible files**:
+   - For each Figma property (spacing, colors, shadows, etc.)
+   - Determine which file's code actually implements it
+   - Create a property-to-file mapping
+
+4. **Save dependency analysis** to `.temp/component-updates/{component-name}/dependencies.md`:
+   ```markdown
+   # Dependency Analysis: {ComponentName}
+   
+   ## Internal Dependencies
+   | Component | Path | Has Figma Source? |
+   |-----------|------|-------------------|
+   | BaseEditable | ../BaseEditable | Yes (node 1252-9022) |
+   | EditControls | ../EditControls | No |
+   
+   ## Property Ownership Map
+   | Figma Property | Responsible File | Current Value |
+   |----------------|------------------|---------------|
+   | Label-Content Gap | BaseEditable.tsx | gap-1 (4px) |
+   | Content Padding | BaseEditable.tsx | py-0.5 (2px) |
+   | Button Shadow | EditControls.tsx | shadow-sm |
+   | Input Border | EditableText.tsx | border-input |
+   ```
+
+### Step 3: Generate Comparison
+
+Create `.temp/component-updates/{component-name}/comparison.md`:
+
+**IMPORTANT:** Only include differences and decisions. Do NOT include:
+- Figma Design Summary sections
+- Current Implementation Summary sections  
+- "Previously Matching" or "No Changes Needed" sections
+
+```markdown
+# Component Comparison: {ComponentName}
+
+> Figma: https://www.figma.com/design/...?node-id=...
+
+## Differences
+
+### 📁 {ComponentName}.tsx
+
+#### 1. Border color
+- **Figma:** `border-gray-300`
+- **Code:** `border-input`
+- **Impact:** Low
+
+**Decision:**
+- [ ] 🔧 IMPLEMENT
+- [ ] ✅ ACCEPT - Reason: 
+- [ ] ⏭️ SKIP
+
+---
+
+### 📁 BaseEditable.tsx (dependency)
+
+#### 1. Label-Content Gap
+- **Figma:** `0px` (no gap)
+- **Code:** `gap-1` (4px)
+- **Impact:** Medium
+
+**Decision:**
+- [ ] 🔧 IMPLEMENT
+- [ ] ✅ ACCEPT - Reason: 
+- [ ] ⏭️ SKIP
+
+#### 2. Content Padding
+- **Figma:** `py-2` (8px)
+- **Code:** `py-0.5` (2px)
+- **Impact:** Medium
+
+**Decision:**
+- [ ] 🔧 IMPLEMENT
+- [ ] ✅ ACCEPT - Reason: 
+- [ ] ⏭️ SKIP
+
+---
+
+## Previously Accepted
+
+| Category | Figma | Code | File | Reason |
+|----------|-------|------|------|--------|
+| Width | fixed | `w-full` | {ComponentName}.tsx | Container flexibility |
+```
+
+### Step 4: User Review
+
+Prompt the user to:
+1. Open the `comparison.md` file
+2. Review each difference (grouped by file)
+3. Mark decisions inline
+4. Save the file
+
+Use this prompt format:
+```
+📋 Component sync analysis complete!
+
+Found differences in {N} files:
+- {ComponentName}.tsx: {n} differences
+- BaseEditable.tsx (dependency): {n} differences
+- EditControls.tsx (dependency): {n} differences
+
+Please review and make decisions:
+1. Open: `.temp/component-updates/{component-name}/comparison.md`
+2. For each difference, choose: IMPLEMENT, ACCEPT, or SKIP
+3. Save the file
+4. Tell me to apply the decisions
+```
+
+### Step 5: Apply Decisions
+
+After user completes review:
+
+1. **Parse the comparison.md** for decisions (grouped by file)
+2. **For IMPLEMENT decisions**:
+   - Generate a technical plan per file
+   - Apply code changes to each file
+   - Run tests to verify
+3. **For ACCEPT decisions**:
+   - Add to the **target component's** README.md under "## Accepted Design Differences"
+   - Include which file the deviation is in
+4. **For SKIP decisions**:
+   - Leave as-is for future review
+
+**Important:** When changing dependency files (like `BaseEditable`), consider:
+- These changes affect ALL components using that dependency
+- Document the change scope in the implementation plan
+- Run broader test coverage if needed
+
+## Output Files Structure
+
+```
+.temp/component-updates/{component-name}/
+├── figma-context.md          # Raw Figma MCP output
+├── dependencies.md           # Internal dependency analysis & property mapping
+├── technical-comparison.md   # Side-by-side property comparison
+├── decisions.md              # Grouped changes with decision checkboxes
+└── implementation-plan.md    # Generated after review (if changes needed)
+```
+
+## README.md Format for Accepted Differences
+
+Components should document accepted differences in their README:
+
+```markdown
+# ComponentName
+
+Description...
+
+## Figma Source
+
+https://www.figma.com/design/...
+
+## Accepted Design Differences
+
+| Category | Figma | Implementation | File | Reason |
+|----------|-------|----------------|------|--------|
+| Width | Fixed 200px | `w-full` | EditableText.tsx | Container flexibility |
+| Gap | 0px | `gap-1` (4px) | BaseEditable.tsx | Visual breathing room |
+| Shadow | `shadow-lg` | `shadow-sm` | EditControls.tsx | Subtler appearance |
+```
+
+## Dependency Detection Rules
+
+When tracing dependencies, include a component if:
+
+1. **It's imported from a relative path** within the same component family
+   - ✅ `import { BaseEditable } from '../BaseEditable'`
+   - ✅ `import { EditControls } from '../EditControls'`
+   - ❌ `import { Button } from '@/components/ui/button'` (external UI lib)
+   - ❌ `import { cn } from '@/lib/utils'` (utility, not component)
+
+2. **It renders visual elements** (not just hooks or utilities)
+
+3. **It implements styling** that corresponds to Figma properties:
+   - Layout (flex, gap, padding, margin)
+   - Colors (background, text, border)
+   - Typography (font size, weight, line-height)
+   - Effects (shadow, border-radius)
+
+## Property-to-File Mapping Guidelines
+
+When determining which file "owns" a Figma property:
+
+| Figma Element | Usually Owned By |
+|---------------|------------------|
+| Label styling | Base/wrapper component |
+| Content area styling | Base/wrapper component |
+| Edit mode container | Target component |
+| Input field styling | Target component |
+| Save/Cancel buttons | Controls component |
+| Hover states | Base/wrapper component |
+| Focus rings | Usually the focused element's component |
+
+## Example Usage
+
+**Check a single component:**
+```
+Check the EditableText component against its Figma design
+```
+
+**Check all inline-edit components:**
+```
+Check all components in packages/client/src/components/inline-edit/ against their Figma designs
+```
+
+**Apply decisions after review:**
+```
+Apply the figma sync decisions for EditableText
+```
+
+## Prompts for Follow-up Actions
+
+After generating comparison.md, provide these follow-up prompts:
+
+### To apply changes:
+```
+@workspace Read .temp/component-updates/{component-name}/comparison.md and implement all changes marked as IMPLEMENT
+```
+
+### To update README with accepted deviations:
+```
+@workspace Read .temp/component-updates/{component-name}/comparison.md and add all ACCEPT decisions to the component's README.md
+```
+
+## Common Figma Properties to Check
+
+| Category | Figma Property | Code Equivalent |
+|----------|---------------|-----------------|
+| Colors | Fill colors | `bg-*`, `text-*`, CSS colors |
+| Typography | Font size/weight | `text-*`, `font-*` |
+| Spacing | Auto layout gaps | `gap-*`, `space-*`, `p-*`, `m-*` |
+| Borders | Stroke | `border-*`, `ring-*` |
+| Shadows | Effects | `shadow-*` |
+| Corners | Corner radius | `rounded-*` |
+| Sizing | Width/Height | `w-*`, `h-*`, `min-*`, `max-*` |
+
+## Troubleshooting
+
+### "No Figma link found"
+- Ensure README.md exists in the component folder
+- Check the link format matches expected pattern
+
+### "MCP authentication failed"
+- Verify Figma MCP is configured
+- Run `mcp_figma_whoami` to check auth status
+
+### "Component not found at path"
+- Verify the component path is correct
+- Check for typos in component name

--- a/.claude/skills/figma-component-sync/examples/comparison-template.md
+++ b/.claude/skills/figma-component-sync/examples/comparison-template.md
@@ -1,0 +1,61 @@
+# Component Comparison: EditableText
+
+> Figma: https://www.figma.com/design/7QW0kJ07DcM36mgQUJ5Dtj/Carton-Case-Management?node-id=1261-9396
+
+## Differences
+
+### 📁 EditableText.tsx
+
+#### 1. Input Shadow
+- **Figma:** `shadow-xs` (0px 1px 2px rgba(0,0,0,0.05))
+- **Code:** `shadow-sm`
+- **Impact:** Low
+
+**Decision:**
+- [ ] 🔧 IMPLEMENT
+- [ ] ✅ ACCEPT - Reason: 
+- [ ] ⏭️ SKIP
+
+---
+
+### 📁 BaseEditable.tsx (dependency)
+
+⚠️ Changes affect all inline-edit components
+
+#### 1. Label-Content Gap
+- **Figma:** `0px` (no gap)
+- **Code:** `gap-1` (4px)
+- **Impact:** Low
+
+**Decision:**
+- [ ] 🔧 IMPLEMENT
+- [ ] ✅ ACCEPT - Reason: 
+- [ ] ⏭️ SKIP
+
+#### 2. Content Padding
+- **Figma:** `py-2` (8px)
+- **Code:** `py-0.5` (2px)
+- **Impact:** Medium
+
+**Decision:**
+- [ ] 🔧 IMPLEMENT
+- [ ] ✅ ACCEPT - Reason: 
+- [ ] ⏭️ SKIP
+
+#### 3. Content Font Weight
+- **Figma:** `font-medium` (500)
+- **Code:** inherited (400)
+- **Impact:** Low
+
+**Decision:**
+- [ ] 🔧 IMPLEMENT
+- [ ] ✅ ACCEPT - Reason: 
+- [ ] ⏭️ SKIP
+
+---
+
+## Previously Accepted
+
+| Category | Figma | Code | File | Reason |
+|----------|-------|------|------|--------|
+| Content Height | `h-9` (36px) | auto | BaseEditable.tsx | Flexible content support |

--- a/.claude/skills/figma-component-sync/examples/figma-context-template.md
+++ b/.claude/skills/figma-component-sync/examples/figma-context-template.md
@@ -1,0 +1,71 @@
+# Figma Context Output
+
+> Component: {COMPONENT_NAME}
+> Figma URL: {FIGMA_URL}
+> Fetched: {TIMESTAMP}
+
+---
+
+## Raw Design Context
+
+<!-- Paste mcp_figma_get_design_context output below -->
+
+```
+{FIGMA_CONTEXT_OUTPUT}
+```
+
+---
+
+## Extracted Design Specifications
+
+### Component Structure
+<!-- List the component hierarchy from Figma -->
+
+### Visual Properties
+
+| Property | Value | Tailwind Equivalent |
+|----------|-------|---------------------|
+| Width | | |
+| Height | | |
+| Background | | |
+| Border | | |
+| Border Radius | | |
+| Shadow | | |
+| Padding | | |
+| Gap | | |
+
+### Typography
+
+| Element | Size | Weight | Color | Line Height | Letter Spacing |
+|---------|------|--------|-------|-------------|----------------|
+| | | | | | |
+
+### Colors Used
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| | | |
+
+### States
+
+| State | Visual Changes |
+|-------|---------------|
+| Rest | |
+| Hover | |
+| Focus | |
+| Active | |
+| Disabled | |
+
+---
+
+## Parent Context
+
+<!-- If parent README had a Figma link, include that context here -->
+
+### Parent Figma URL
+{PARENT_FIGMA_URL}
+
+### Parent Context Output
+```
+{PARENT_FIGMA_CONTEXT}
+```

--- a/.claude/skills/figma-connect-component/SKILL.md
+++ b/.claude/skills/figma-connect-component/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: figma-connect-component
+description: User provides a Figma component URL and wants to generate the Code Connect mapping for it.
+---
+# Generate Figma Code Connect for React Components
+
+## When to Use This Skill
+User provides a Figma component URL (or component name) and wants to generate the Code Connect mapping for it.
+
+## Required Inputs
+1. **Figma component identifier** (one of):
+   - Full URL: `https://figma.com/design/{fileKey}/{fileName}?node-id={nodeId}`
+   - File key + node ID: `fileKey: abc123, nodeId: 45:67`
+   - Evidence file path: `.temp/figma-explore/{component}.json` or `.temp/figma-connect-shadcn/{component}.json`
+   - Component name (will search for URL in project files)
+2. **Code component folder path** (e.g., `src/components/Button/Button.tsx`)
+
+## Execution Steps
+
+### 1. Gather Figma Component Data
+
+**Option A: Evidence File Provided (Preferred)**
+
+If an evidence file from `figma-explore` is provided (e.g., `.temp/figma-explore/{component}.json`):
+- Read the JSON file directly
+- Extract: `id` (node ID), `name`, `variants`, `variantProperties`, `componentPropertyDefinitions`
+- The file contains all the variant names and values needed for Code Connect
+
+Example evidence file structure:
+```json
+{
+  "id": "16:1234",
+  "name": "Button",
+  "type": "COMPONENT_SET",
+  "variants": [
+    { "name": "Type=Primary, Size=Small", "id": "16:1235" },
+    { "name": "Type=Primary, Size=Large", "id": "16:1236" }
+  ],
+  "variantProperties": {
+    "Type": ["Primary", "Secondary", "Ghost"],
+    "Size": ["Small", "Medium", "Large"]
+  },
+  "componentPropertyDefinitions": {
+    "Label": { "type": "TEXT", "defaultValue": "Button" },
+    "Show Icon": { "type": "BOOLEAN", "defaultValue": false }
+  }
+}
+```
+
+**Option B: URL/Node ID Provided (MCP Fallback)**
+
+If only a Figma URL or node ID is provided:
+
+1. **Search for existing evidence files** in `.temp/figma-explore/` or `.temp/figma-connect-shadcn/` that match the component name
+2. **If not found, use MCP tools**:
+   - Call `mcp_figma_get_metadata` with `nodeId` and `fileKey`
+   - Call `mcp_figma_get_design_context` with `nodeId` and `fileKey`
+
+### 2. Discover Figma URL (if needed)
+If no URL or evidence file provided, search for it:
+1. Check `{ComponentFolder}/README.md` for "Figma Source" section
+2. Check `specs/**/tasks.md` for component-to-Figma mapping tables
+3. Check `.temp/figma-explore/figma-components-index.json` or `.temp/figma-connect-shadcn/figma-components-index.json` for matching component names
+4. Check prior conversation context for file key
+
+### 3. Read Code Component
+- Read the specified component file
+- Identify: exports, props interface, component name
+
+### 4. Generate Mapping
+- Map Figma properties to code props using `figma.*` helpers
+- Build example JSX template
+- Add appropriate imports
+
+### 5. Write Code Connect File
+- Output to: `{ComponentFolder}/{ComponentName}.figma.tsx`
+- Raw file content only—no markdown fences
+
+### 6. Update README with Mapping Diagram
+If `{ComponentFolder}/README.md` exists, ensure it has a **Design-to-Code Mapping** section with a mermaid flowchart at the top showing the Figma-to-React property relationships.
+
+**Diagram format:**
+```mermaid
+flowchart LR
+    subgraph Figma["Figma Variants"]
+        FProp1["PropertyName1"]
+        FProp2["PropertyName2"]
+    end
+
+    subgraph React["React Props"]
+        RProp1["propName1"]
+        RProp2["propName2"]
+    end
+
+    FProp1 -->|"Value1 → 'code1'<br>Value2 → 'code2'"| RProp1
+    FProp2 -->|"mapping description"| RProp2
+
+    style Figma fill:#f3e8ff,stroke:#9333ea
+    style React fill:#dbeafe,stroke:#3b82f6
+```
+
+**Placement:** The mermaid diagram should be placed immediately after the `## Design-to-Code Mapping` heading, before any tables.
+
+**Example README structure:**
+```markdown
+## Design-to-Code Mapping
+
+```mermaid
+flowchart LR
+    subgraph Figma["Figma Variants"]
+        FSize["Size"]
+        FType["Type"]
+    end
+
+    subgraph React["React Props"]
+        RSize["size"]
+        RVariant["variant"]
+    end
+
+    FSize -->|"Small → 'sm'<br>Medium → 'md'<br>Large → 'lg'"| RSize
+    FType -->|"Primary → 'primary'<br>Secondary → 'secondary'"| RVariant
+
+    style Figma fill:#f3e8ff,stroke:#9333ea
+    style React fill:#dbeafe,stroke:#3b82f6
+` ` `
+
+### Variant Mappings
+| Figma Variant | Figma Value | React Prop | React Value |
+...
+```
+
+**Rules for the diagram:**
+- Include all mapped variant properties (from `figma.enum()` calls)
+- Include boolean properties that map to React props
+- Show value transformations on the arrows (e.g., `"Small → 'sm'"`)
+- Use `<br>` for multiple value mappings on one arrow
+- Exclude pseudo-states (hover, focus, pressed) from the diagram
+- Use purple styling for Figma subgraph, blue for React subgraph
+
+## Rules
+
+### Use Exact Figma Property Names
+**Critical:** Code Connect requires the EXACT property names as they appear in Figma.
+
+- Get exact names from evidence files (`.figma-components/*.json`) or `get_metadata` output
+- Property names like `ButtonType`, `Type`, `Size` must match EXACTLY (case-sensitive)
+- The `get_design_context` MCP tool normalizes to camelCase - **do NOT use those names**
+- Property names are case-sensitive: `Size` ≠ `size`
+
+Example from metadata:
+```
+name="ButtonType=Responsive, Type=Primary, Size=Small"
+```
+Use in Code Connect:
+```tsx
+variant: { ButtonType: 'Responsive' },  // ✅ Exact match
+props: {
+  size: figma.enum('Size', { ... }),    // ✅ Exact match
+  variant: figma.enum('Type', { ... }), // ✅ Exact match
+}
+```
+
+### Only Use Real Figma Properties
+Map based on what exists in Figma:
+- **Component properties** → `figma.boolean()`, `figma.string()`, `figma.instance()`
+- **Variant properties** → `figma.enum()`
+- **Text layers** → `figma.textContent('LayerName')`
+- **Nested instances** → `figma.children('LayerName')` or `figma.children('*')`
+- **Child component props** → `figma.nestedProps('LayerName', { ... })`
+
+**Never invent properties that don't exist in Figma.**
+
+### Value Conventions
+- Drop pseudo-state variants: `hover`, `pressed`, `focused`, `state`, `interaction`
+- Map Figma Title Case to code: `Primary` → `'primary'`, `Small` → `'sm'`
+- Normalize boolean variants: "Yes"/"No", "True"/"False", "On"/"Off" → `true`/`false`
+
+### Critical Constraint: No JavaScript Expressions
+Code Connect snippets are **strings, NOT executed code**.
+
+**NEVER use:**
+```tsx
+{hasIcon && <Icon />}
+{disabled ? 'disabled' : ''}
+{icon || <Fallback />}
+```
+
+**Instead, use mapping objects:**
+```tsx
+figma.boolean('Has Icon', {
+  true: <Icon />,
+  false: undefined
+})
+```
+
+## API Reference
+
+### Basic Helpers
+
+```tsx
+// String property
+figma.string('Label')
+
+// Boolean property (simple)
+figma.boolean('Disabled')
+
+// Boolean with mapping
+figma.boolean('Has Icon', {
+  true: <Icon />,
+  false: undefined
+})
+
+// Conditional string based on boolean
+figma.boolean('Has label', {
+  true: figma.string('Label'),
+  false: undefined
+})
+
+// Enum/Variant property
+figma.enum('Size', {
+  'Small': 'sm',
+  'Medium': 'md',
+  'Large': 'lg'
+})
+
+// Text content from a layer
+figma.textContent('Button Label')
+
+// Instance swap property (nested component)
+figma.instance('Icon')
+
+// Child instances by layer name
+figma.children('Tab')
+figma.children(['Tab 1', 'Tab 2'])
+figma.children('Icon*')  // wildcard
+figma.children('*')      // all children
+```
+
+### Advanced Helpers
+
+```tsx
+// Nested props - access child component's properties on parent
+figma.nestedProps('Button Shape', {
+  size: figma.enum('Size', { ... })
+})
+
+// className builder
+figma.className([
+  'btn-base',
+  figma.enum('Size', { 'Large': 'btn-large' }),
+  figma.boolean('Disabled', { true: 'btn-disabled', false: '' })
+])
+
+// Instance with type inference
+figma.instance<React.FunctionComponent>('Icon')  // Returns component type
+figma.instance<string>('Icon')                    // Returns string ID
+
+// Access nested instance props in parent
+figma.instance('Icon').getProps<{ iconId: string, size: 'sm' | 'lg' }>()
+
+// Custom render for nested instance
+figma.instance('Icon').render<{ id: string }>(props => <CustomIcon id={props.id} />)
+```
+
+### Variant Restrictions
+Use when one Figma component maps to multiple code components:
+
+```tsx
+figma.connect(PrimaryButton, 'https://...', {
+  variant: { Type: 'Primary' },
+  example: () => <PrimaryButton />
+})
+
+figma.connect(SecondaryButton, 'https://...', {
+  variant: { Type: 'Secondary' },
+  example: () => <SecondaryButton />
+})
+
+// Boolean variant restriction
+figma.connect(IconButton, 'https://...', {
+  variant: { 'Has Icon': true },
+  example: () => <IconButton />
+})
+
+// Multiple variant combination
+figma.connect(DangerButton, 'https://...', {
+  variant: { Type: 'Danger', Disabled: true },
+  example: () => <DangerButton />
+})
+```
+
+## Complete Example
+
+```tsx
+import figma from '@figma/code-connect'
+import { Button } from './Button'
+
+figma.connect(Button, 'https://figma.com/design/abc123/File?node-id=1:2', {
+  props: {
+    variant: figma.enum('Variant', {
+      Primary: 'primary',
+      Secondary: 'secondary'
+    }),
+    size: figma.enum('Size', {
+      Small: 'sm',
+      Medium: 'md',
+      Large: 'lg'
+    }),
+    disabled: figma.boolean('Disabled'),
+    label: figma.textContent('Label'),
+    icon: figma.boolean('Has Icon', {
+      true: figma.instance('Icon'),
+      false: undefined
+    })
+  },
+  example: ({ variant, size, disabled, label, icon }) => (
+    <Button variant={variant} size={size} disabled={disabled} icon={icon}>
+      {label}
+    </Button>
+  )
+})
+```
+
+## Icon Connection Patterns
+
+### Icons as JSX Elements
+```tsx
+// Icon component
+figma.connect('https://...icon-url...', {
+  example: () => <IconHeart />
+})
+
+// Parent using the icon
+figma.connect(Button, 'https://...button-url...', {
+  props: {
+    icon: figma.instance('Icon')
+  },
+  example: ({ icon }) => <Button>{icon}</Button>
+})
+// Renders: <Button><IconHeart/></Button>
+```
+
+### Icons as React Components
+```tsx
+// Icon returns component reference (not JSX)
+figma.connect('https://...icon-url...', {
+  example: () => IconHeart  // No angle brackets
+})
+
+// Parent receives component type
+figma.connect(Button, 'https://...', {
+  props: {
+    Icon: figma.instance<React.FunctionComponent>('Icon')
+  },
+  example: ({ Icon }) => <Button Icon={Icon} />
+})
+// Renders: <Button Icon={IconHeart} />
+```
+
+### Icons as String IDs
+```tsx
+// Icon returns string ID
+figma.connect('https://...icon-url...', {
+  example: () => 'icon-heart'
+})
+
+// Parent uses string
+figma.connect(Button, 'https://...', {
+  props: {
+    iconId: figma.instance<string>('Icon')
+  },
+  example: ({ iconId }) => <Button iconId={iconId} />
+})
+// Renders: <Button iconId="icon-heart" />
+```
+
+## Output
+
+Write raw file content only—no markdown fences, no explanations.
+
+**File location:** `{ComponentFolder}/{ComponentName}.figma.tsx`
+
+Example: `src/components/inline-edit/EditableText/EditableText.figma.tsx`
+
+File must be immediately usable with `npx @figma/code-connect connect publish`.

--- a/.claude/skills/figma-connect-shadcn/SKILL.md
+++ b/.claude/skills/figma-connect-shadcn/SKILL.md
@@ -1,0 +1,359 @@
+---
+name: figma-connect-shadcn
+description: Connect shadcn/ui components to their Figma design system counterparts using Code Connect.
+---
+# Connect shadcn/ui Components to Figma
+
+## When to Use This Skill
+- User wants to connect shadcn/ui components to Figma
+- User just added new shadcn components via `npx shadcn@latest add <component>`
+- Running as part of CI/CD to keep Figma connections in sync
+- Periodic audit to find unconnected components
+
+## Incremental Behavior
+This skill is **incremental by default**:
+- Scans for `.figma.tsx` files next to each component
+- Only processes components that are **missing** their Code Connect file
+- Skips components that already have connections
+- Reports both "already connected" and "newly connected" in final summary
+
+To **force reconnection** of all components, user must explicitly request it.
+
+## Prerequisites
+
+### 1. FIGMA_ACCESS_TOKEN
+Ensure `.env` has a valid Figma token:
+```bash
+FIGMA_ACCESS_TOKEN=figd_...
+```
+
+Get one from: https://www.figma.com/developers/api#access-tokens
+
+### 2. Locate shadcn Configuration
+Find the `components.json` file to determine:
+- **Component output path**: Check `aliases.ui` (typically `@/components/ui`)
+- **Style variant**: `style` field (e.g., `"new-york"` or `"default"`)
+- **Icon library**: `iconLibrary` field (e.g., `"lucide"`)
+
+## Required Inputs
+1. **Figma file URL**: The Figma file containing shadcn component designs
+2. **shadcn component folder**: Auto-discovered from `components.json` → typically `src/components/ui/`
+
+## Execution Steps
+
+### Step 1: Extract Figma Components
+
+**Use the `figma-explore` skill's script** to get all components from the Figma file:
+
+```bash
+source .env && node .claude/skills/figma-explore/figma-extract-all.js "<figmaUrl>" --output .temp/figma-connect-shadcn
+```
+
+This creates:
+- `.temp/figma-connect-shadcn/figma-components-index.json` - List of all Figma components
+- `.temp/figma-connect-shadcn/<component>.json` - Evidence for each component
+
+**If the script fails**, check:
+- Token expired? Regenerate at https://www.figma.com/developers/api#access-tokens
+- No access? User may need to duplicate a Community file to their account
+
+### Step 2: Discover Project Configuration
+
+Read `components.json` and write notes to `.temp/figma-connect-shadcn/shadcn-discovery.md`:
+
+```markdown
+# shadcn/ui Discovery Notes
+
+## Configuration (from components.json)
+- Style: {style}
+- UI Path: {aliases.ui}
+- Icon Library: {iconLibrary}
+- Tailwind CSS Variables: {tailwind.cssVariables}
+
+## Installed Components
+{list of .tsx files in ui folder, excluding .stories.tsx and .test.tsx}
+
+## Figma Source
+- File Key: {fileKey}
+- Components Found: {count from figma-components-index.json}
+```
+
+### Step 3: Inventory shadcn Components
+
+Scan the UI components folder:
+
+```bash
+# Expected location from components.json aliases.ui
+packages/client/src/components/ui/
+```
+
+**For each `.tsx` file**, check if a corresponding `.figma.tsx` exists:
+- `button.tsx` → check for `button.figma.tsx`
+- `card.tsx` → check for `card.figma.tsx`
+
+**Filter out non-component files:**
+- `*.stories.tsx` (Storybook)
+- `*.test.tsx` (tests)
+- `*.figma.tsx` (Code Connect files themselves)
+- `index.ts` (barrel exports)
+
+Write to `.temp/figma-connect-shadcn/shadcn-components.md`:
+
+```markdown
+# shadcn Components Inventory
+
+## Summary
+- Total components: 14
+- Already connected: 8 ✅
+- Need connection: 6 ⏳
+
+## Component Status
+| Component | File | Figma Connect | Status |
+|-----------|------|---------------|--------|
+| Button | button.tsx | button.figma.tsx | ✅ Already connected |
+| Card | card.tsx | - | ⏳ Needs connection |
+...
+```
+
+### Step 4: Match shadcn to Figma Components
+
+Read `.temp/figma-connect-shadcn/figma-components-index.json` and match shadcn component names to Figma components.
+
+**Matching strategy:**
+1. Exact name match (case-insensitive): `button.tsx` → `Button`
+2. Common aliases: `input.tsx` → `Input` or `Text Field` or `TextField`
+3. Compound components: `card.tsx` → `Card` (matches CardHeader, CardContent, etc.)
+
+Write to `.temp/figma-connect-shadcn/shadcn-figma-mapping.md`:
+
+```markdown
+# shadcn → Figma Component Mapping
+
+| shadcn Component | Figma Component | Node ID | Evidence File |
+|------------------|-----------------|---------|---------------|
+| button | Button | 16:1234 | button.json |
+| card | Card | 16:2345 | card.json |
+| select | Select & Combobox | 16:1730 | select_combobox.json |
+| skeleton | - | - | ❌ No match |
+```
+
+### Step 5: Generate Connection Tasks
+
+**Only create tasks for components that need connection** (from Step 3's inventory) and have a Figma match (from Step 4's mapping).
+
+Write to `.temp/figma-connect-shadcn/shadcn-connect-tasks.md`:
+
+```markdown
+# Code Connect Tasks
+
+## Run Info
+- Date: {timestamp}
+- Total shadcn components: 14
+- Already connected: 8 (skipped)
+- No Figma match: 1 (skipped)
+- Tasks to run: 5
+
+## Tasks to Execute
+Each task will be executed by a subagent with the figma-connect-component skill.
+
+### Task 1: Card
+- **Code Path**: packages/client/src/components/ui/card.tsx
+- **Figma Node ID**: 16:2345
+- **Figma URL**: https://figma.com/design/{fileKey}?node-id=16-2345
+- **Evidence File**: .temp/figma-connect-shadcn/card.json
+- **Output**: packages/client/src/components/ui/card.figma.tsx
+- **Status**: ⏳ Pending
+
+### Task 2: Input
+- **Code Path**: packages/client/src/components/ui/input.tsx
+- **Figma Node ID**: 16:3456
+- **Figma URL**: https://figma.com/design/{fileKey}?node-id=16-3456
+- **Evidence File**: .temp/figma-connect-shadcn/input.json
+- **Output**: packages/client/src/components/ui/input.figma.tsx
+- **Status**: ⏳ Pending
+
+...
+
+## Skipped - Already Connected
+| Component | Existing File |
+|-----------|---------------|
+| Button | button.figma.tsx |
+| Calendar | calendar.figma.tsx |
+...
+
+## Skipped - No Figma Match
+- skeleton.tsx (no corresponding Figma component found in index)
+```
+
+### Step 6: Execute Tasks via Subagents
+
+**Only process tasks with "⏳ Pending" status** from the tasks document.
+
+**Before spawning subagents:** Read the full contents of `.claude/skills/figma-connect-component/SKILL.md` and store it. Subagents cannot access skill files directly, so you must inline the instructions.
+
+For each pending task, spawn a subagent with:
+1. The skill instructions (inlined)
+2. The component code path
+3. The Figma evidence file content (read from `.figma-components/{name}.json`)
+4. The output path for the `.figma.tsx` file
+
+```typescript
+// First, read the skill file (do this once before the loop)
+const skillInstructions = readFile('.claude/skills/figma-connect-component/SKILL.md')
+
+// Then for each pending task:
+const evidenceFile = readFile(`.temp/figma-connect-shadcn/${componentName}.json`)
+
+runSubagent({
+  description: "Connect Card to Figma",
+  prompt: `
+    Create a Figma Code Connect file for a React component.
+    
+    ## Inputs
+    - Component Path: packages/client/src/components/ui/card.tsx
+    - Figma File Key: ${fileKey}
+    - Figma Node ID: 16:2345
+    - Output Path: packages/client/src/components/ui/card.figma.tsx
+    
+    ## Figma Component Evidence
+    \`\`\`json
+    ${JSON.stringify(evidenceFile, null, 2)}
+    \`\`\`
+    
+    ## Instructions
+    Follow these instructions to create the Code Connect file:
+    
+    ${skillInstructions}
+    
+    ## Return
+    Return the file path of the created .figma.tsx file, or an error message if failed.
+  `
+})
+```
+
+Update each task status in the document as it completes (⏳ → ✅ or ❌).
+
+### Step 7: Verify and Report
+
+After all subagents complete, update `.temp/figma-connect-shadcn/shadcn-connect-tasks.md` with final summary:
+
+```markdown
+## Run Summary
+- **Run Date**: 2026-01-16 14:30
+- **Total shadcn components**: 14
+- **Already connected (before run)**: 8
+- **Tasks attempted**: 6
+- **Successful**: 5
+- **Failed**: 1
+
+## Newly Created
+| Component | Figma Connect File | Status |
+|-----------|-------------------|--------|
+| Card | card.figma.tsx | ✅ Created |
+| Input | input.figma.tsx | ✅ Created |
+| Textarea | textarea.figma.tsx | ✅ Created |
+| Select | select.figma.tsx | ✅ Created |
+| Label | label.figma.tsx | ✅ Created |
+
+## Failed
+| Component | Error |
+|-----------|-------|
+| Tooltip | No matching Figma component found |
+
+## Previously Connected (Unchanged)
+Button, Calendar, DatePicker, ... (8 components)
+
+## Next Steps
+Run `npx @figma/code-connect publish` to push connections to Figma.
+```
+
+## shadcn-Specific Mapping Rules
+
+### Component Name Mapping
+| shadcn Export | Typical Figma Name |
+|---------------|-------------------|
+| `Button` | `Button` |
+| `Card`, `CardHeader`, `CardTitle`, `CardContent` | `Card` (compound) |
+| `Input` | `Input` / `Text Field` |
+| `Label` | `Label` |
+| `Select`, `SelectTrigger`, `SelectContent` | `Select` / `Dropdown` |
+| `Sheet`, `SheetTrigger`, `SheetContent` | `Sheet` / `Drawer` / `Side Panel` |
+| `AlertDialog` | `Alert Dialog` / `Modal` |
+| `DropdownMenu` | `Dropdown Menu` / `Menu` |
+
+### Variant Mapping (shadcn → Figma)
+```tsx
+// shadcn uses lowercase variants
+variant: figma.enum('Variant', {
+  'Default': 'default',
+  'Destructive': 'destructive',
+  'Outline': 'outline',
+  'Secondary': 'secondary',
+  'Ghost': 'ghost',
+  'Link': 'link'
+})
+
+size: figma.enum('Size', {
+  'Default': 'default',
+  'Small': 'sm',
+  'Large': 'lg',
+  'Icon': 'icon'
+})
+```
+
+### Compound Component Pattern
+shadcn uses compound components. Connect the root and document composition:
+
+```tsx
+import figma from '@figma/code-connect'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from './card'
+
+// Connect the main Card component
+figma.connect(Card, 'https://figma.com/...', {
+  props: {
+    children: figma.children('*')
+  },
+  example: ({ children }) => (
+    <Card>
+      <CardHeader>
+        <CardTitle>Title</CardTitle>
+        <CardDescription>Description</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {children}
+      </CardContent>
+      <CardFooter>
+        Footer content
+      </CardFooter>
+    </Card>
+  )
+})
+```
+
+## Output Files
+
+All work files go in `.temp/figma-connect-shadcn/`:
+- `figma-components-index.json` - Index of all Figma components
+- `<component>.json` - Detailed evidence per component (e.g., `button.json`)
+- `shadcn-discovery.md` - Configuration findings
+- `shadcn-components.md` - Component inventory
+- `shadcn-figma-mapping.md` - Figma node mappings
+- `shadcn-connect-tasks.md` - Task list and status
+
+### Final Code Connect Files
+Code Connect files go next to components:
+- `packages/client/src/components/ui/button.figma.tsx`
+- `packages/client/src/components/ui/card.figma.tsx`
+- etc.
+
+## Verification
+
+After all connections are created:
+
+```bash
+# Validate connections
+npx @figma/code-connect parse
+
+# Publish to Figma
+npx @figma/code-connect publish
+```

--- a/.claude/skills/figma-design-react/SKILL.md
+++ b/.claude/skills/figma-design-react/SKILL.md
@@ -1,0 +1,387 @@
+---
+name: figma-design-react
+description: Design React components from Figma files. Use when given a Figma URL to analyze a design and propose React component architecture, props API, and variant handling. Outputs design analysis and suggested API - does not build components.
+---
+
+# Skill: Design React Components from Figma
+
+This skill analyzes Figma designs and proposes React component architecture and props APIs. It helps bridge the gap between design and implementation by providing clear specifications before coding begins.
+
+## When to Use
+
+- User provides a Figma URL and wants to understand how to implement it as React
+- Planning component architecture before implementation
+- Determining what props a component should have based on Figma variants
+- Deciding if a Figma component should be one or multiple React components
+
+## What This Skill Does NOT Do
+
+- Build or implement the actual React components
+- Generate production code
+- Create Code Connect mappings (use `figma-connect-component` for that)
+- Sync existing components with Figma (use `figma-component-sync` for that)
+
+## Required Inputs
+
+1. **Figma URL**: Full URL like `https://figma.com/design/{fileKey}/{fileName}?node-id={nodeId}`
+
+## Design Principle
+
+**Follow FIGMA structure exactly**
+
+When designing component APIs from Figma:
+
+- **DO NOT** use any other component library as a reference
+- **DO NOT** impose external component patterns or best practices
+- **DO** use the Figma design as the single source of truth for component structure
+- **DO** match the exact component hierarchy, variant structure, and prop organization shown in Figma
+
+The component API should mirror how the design is structured in Figma, not how a component library would implement it. If Figma shows variants that change DOM structure, layout, or element ordering, the component API should reflect those structural changes through props.
+
+**Example:**
+- If Figma shows a Type="Mobile" variant with vertical button layout and Type="Desktop" with horizontal layout
+- Then the component should have a `type` prop that controls both layout structure and alignment
+- NOT separate props like `buttonLayout="vertical"` and `textAlign="center"` which would deviate from the Figma structure
+
+## Workflow Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 1. FETCH - Get Figma design context using MCP                  │
+├─────────────────────────────────────────────────────────────────┤
+│ 2. VALIDATE - Screenshot verification                           │
+├─────────────────────────────────────────────────────────────────┤
+│ 3. SAVE - Store design context in .temp/design-components/     │
+├─────────────────────────────────────────────────────────────────┤
+│ 4. ANALYZE - Review variants, properties, and nested components│
+├─────────────────────────────────────────────────────────────────┤
+│ 5. PROPOSE - Suggest component API(s) with props and types     │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Required Flow
+
+**Follow this sequence exactly:**
+
+1. **Run `get_design_context` first** to fetch the structured representation for the exact node(s).
+
+2. **If the response is too large or truncated**, run `get_metadata` to get the high-level node map and then re-fetch only the required node(s) with `get_design_context`.
+
+3. **Run `get_screenshot`** for a visual reference of the node variant being implemented.
+
+4. **Only after you have both `get_design_context` and `get_screenshot`**, download any assets needed and start implementation.
+
+5. **Translate the output** into this project's conventions, styles and framework. Reuse the project's color tokens, components, and typography wherever possible.
+
+6. **Validate against Figma** for 1:1 look and behavior before marking complete.
+
+## Step-by-Step Instructions
+
+### Step 1: Parse Figma URL and Fetch Design Context
+
+Extract from the URL:
+- `fileKey`: The ID after `/design/` (or after `/branch/` if on a branch)
+- `nodeId`: From `node-id=` query param (convert `123-456` → `123:456`)
+
+Call `mcp_figma_get_design_context` with:
+- `nodeId`: The extracted node ID
+- `fileKey`: The extracted file key
+
+### Step 2: Create Output Directory and Save Design Context
+
+Create the output directory:
+```
+.temp/design-components/{COMPONENT_NAME}/
+```
+
+Where `{COMPONENT_NAME}` is derived from the Figma component name (kebab-case).
+
+Save the design context to `.temp/design-components/{COMPONENT_NAME}/design-context.md`:
+
+```markdown
+# Design Context: {ComponentName}
+
+## Figma Source
+{original URL}
+
+## Component Overview
+{Brief description based on Figma data}
+
+## Raw Design Data
+{Full output from mcp_figma_get_design_context}
+```
+
+### Step 3: Analyze Figma Design
+
+Extract and analyze:
+
+1. **Variants and Variant Options**
+   - List all variant properties (e.g., Size, State, Type)
+   - List all options for each variant (e.g., Size: Small, Medium, Large)
+   - Note how variants affect component structure, not just styling
+     - Does the variant change element ordering?
+     - Does it change flex direction or layout?
+     - Does it add/remove elements?
+     - Does it change text alignment or button positioning?
+
+2. **Component Properties**
+   - Boolean properties (e.g., "Has Icon", "Show Label")
+   - String properties (e.g., "Label Text")
+   - Instance swap properties (e.g., "Icon")
+
+3. **Nested Components**
+   - Child component instances
+   - Repeated elements
+
+4. **Text Layers**
+   - Configurable text content
+   - Alignment changes across variants
+
+5. **Structural Differences**
+   - Document how the DOM structure changes between variants
+
+6. **Child Component Configurability Assessment**
+   
+   When the parent component contains nested child component instances (e.g., a Dialog containing Buttons), critically evaluate whether those child components should be configurable by the user.
+   
+   **Common Design Pattern Gap:**
+   Designers may focus on the parent component's variants without considering that child component instances might need different configurations based on the use case. For example:
+   - An `AlertDialog` might always show the same "Cancel" and "Delete" buttons in Figma
+   - But in actual usage, different dialogs need different button variants (destructive vs. primary), labels, and actions
+   
+   **When to Recommend Configurable Child Props:**
+   
+   Consider making child components configurable if:
+   - The child has multiple variants in its own component set (e.g., Button has primary/destructive/outline variants)
+   - Different use cases would require different child configurations
+   - The child component's content or behavior naturally varies (button labels, icons, actions)
+   - The design shows only one variant but others exist and are relevant
+   
+   **How to Handle in API Design:**
+   
+   Instead of hardcoding child components, provide render prop or component prop patterns:
+   
+   ```typescript
+   interface AlertDialogProps {
+     title: string;
+     description: string;
+     
+     // Allow users to pass configured child instances
+     actionButton?: React.ReactNode;
+     cancelButton?: React.ReactNode;
+     
+     // OR use render props for full control
+     renderActions?: (props: { onClose: () => void }) => React.ReactNode;
+   }
+   ```
+   
+   **Example Usage:**
+   ```tsx
+   <AlertDialog
+     title="Delete item?"
+     description="This action cannot be undone."
+     actionButton={
+       <Button variant="destructive" size="default">
+         Delete
+       </Button>
+     }
+     cancelButton={
+       <Button variant="outline" size="default">
+         Cancel
+       </Button>
+     }
+   />
+   ```
+   
+   **Document in Proposed API:**
+   
+   When recommending configurable child components, explain:
+   - Why the child should be configurable (use case flexibility)
+   - What the Figma design shows vs. what's needed in practice
+   - Whether to use component props, render props, or both
+   - Default behavior if props are not provided
+   
+   **Example Documentation:**
+   ```markdown
+   ### Design Consideration: Configurable Buttons
+   
+   **Figma shows:** Fixed "Cancel" and "Delete" buttons with specific variants
+   
+   **Recommended approach:** Make buttons configurable via props
+   
+   **Rationale:** Different alert dialogs need different button configurations:
+   - Destructive actions (delete, remove) need `variant="destructive"`
+   - Confirmations need `variant="primary"`
+   - Button labels vary by context ("Delete", "Remove", "Confirm", etc.)
+   
+   The Figma design represents one use case, but the component should support flexible button configurations to handle all dialog scenarios.
+   ```
+
+### Step 4: Propose Component API
+
+Based on the analysis, create `.temp/design-components/{COMPONENT_NAME}/proposed-api.md`:
+
+```markdown
+# Proposed API: {ComponentName}
+
+## Figma Source
+{original URL}
+
+## Summary
+{One paragraph describing what this component does}
+
+## Recommended Component Structure
+
+{Explain if this should be one component or multiple, and why}
+
+---
+
+## Component: {ComponentName}
+
+### Props Interface
+
+\`\`\`typescript
+interface {ComponentName}Props {
+  // Mapped from Figma variant "Size"
+  size?: 'sm' | 'md' | 'lg';
+  
+  // Mapped from Figma variant "Variant"
+  variant?: 'primary' | 'secondary' | 'outline';
+  
+  // Mapped from Figma boolean "Disabled"
+  disabled?: boolean;
+  
+  // Mapped from Figma text layer "Label"
+  children: React.ReactNode;
+  
+  // Mapped from Figma instance "Icon"
+  icon?: React.ReactNode;
+}
+\`\`\`
+
+### Prop Details
+
+| Prop | Type | Default | Figma Source | Notes |
+|------|------|---------|--------------|-------|
+| size | `'sm' \| 'md' \| 'lg'` | `'md'` | Variant: Size | Maps Small→sm, Medium→md, Large→lg |
+| variant | `'primary' \| 'secondary'` | `'primary'` | Variant: Type | - |
+| disabled | `boolean` | `false` | Boolean: Disabled | - |
+| children | `React.ReactNode` | required | Text: Label | - |
+| icon | `React.ReactNode` | `undefined` | Instance: Icon | Only shown when Has Icon=true |
+
+### Excluded from Props (Handled by Tailwind/Internal State)
+
+| Figma Property | Reason |
+|----------------|--------|
+| State: Hover | Tailwind `hover:` modifier |
+| State: Pressed | Tailwind `active:` modifier |
+| State: Focused | Tailwind `focus-visible:` modifier |
+
+### Example Usage
+
+\`\`\`tsx
+<{ComponentName} size="lg" variant="primary">
+  Click me
+</{ComponentName}>
+
+<{ComponentName} size="sm" icon={<IconPlus />}>
+  Add Item
+</{ComponentName}>
+\`\`\`
+
+---
+
+## Additional Components (if applicable)
+
+{If the Figma component should be split into multiple React components, document each one here with the same structure}
+```
+
+## Decision Guidelines
+
+### When to Create Multiple Components
+
+Create separate components when:
+- Figma variants represent fundamentally different UI patterns (e.g., "Type: Text Input" vs "Type: Date Picker")
+- Variants have completely different props/behavior
+- One variant is a specialized version with unique functionality
+
+Keep as one component when:
+- Variants only affect styling (colors, sizes)
+- All variants share the same props interface
+- Behavior is consistent across variants
+
+### Props to Include vs Exclude
+
+**Include as props:**
+- Variants that change content, behavior, OR structure
+- Boolean toggles for optional elements
+- Text content that should be configurable
+- Instance swaps for customizable slots
+
+**Exclude from props (handle internally):**
+- Pseudo-state variants: `hover`, `pressed`, `focused`, `active`
+- Interaction states: `loading` might be a prop, but visual feedback is internal
+- Animation states
+
+### Naming Conventions
+
+| Figma | React Prop |
+|-------|-----------|
+| `Small`, `Medium`, `Large` | `'sm'`, `'md'`, `'lg'` |
+| `Primary`, `Secondary` | `'primary'`, `'secondary'` |
+| `Has Icon`, `Show Label` | `hasIcon: boolean`, `showLabel: boolean` |
+| `Yes`/`No`, `True`/`False` | `boolean` |
+| Title Case values | kebab-case or camelCase |
+
+## Output Files
+
+```
+.temp/design-components/{component-name}/
+├── design-context.md    # Raw Figma data + URL
+└── proposed-api.md      # Suggested component API(s)
+```
+
+## Example Session
+
+**User:** Design a React component from this Figma: https://figma.com/design/abc123/DesignSystem?node-id=100-200
+
+**Agent:**
+1. Fetches design context via MCP
+2. Creates `.temp/design-components/button/`
+3. Saves `design-context.md` with Figma data
+4. Analyzes variants (Size, Type, State) and properties (Has Icon, Label)
+5. Creates `proposed-api.md` with:
+   - `ButtonProps` interface
+   - Mapping table from Figma to props
+   - Note that State: Hover/Pressed/Focused are handled by CSS
+   - Example usage
+
+**Agent Response:**
+```
+📋 Design analysis complete for Button!
+
+Created: `.temp/design-components/button/`
+
+## Proposed Structure
+Single component: `Button`
+
+## Props Summary
+| Prop | Type | From Figma |
+|------|------|------------|
+| size | 'sm' \| 'md' \| 'lg' | Variant: Size |
+| variant | 'primary' \| 'secondary' | Variant: Type |
+| disabled | boolean | Boolean: Disabled |
+| children | ReactNode | Text: Label |
+| icon | ReactNode | Instance: Icon |
+
+Excluded: Hover, Pressed, Focused states (CSS handles these)
+
+See full details: `.temp/design-components/button/proposed-api.md`
+```
+
+## Related Skills
+
+- **figma-implement-component**: Use this skill next to build the component from the analysis
+- **create-react-modlet**: Defines the modlet folder structure for components
+- **figma-connect-component**: Detailed Code Connect mapping guidance
+- **figma-component-sync**: Use to check existing implementations against Figma designs

--- a/.claude/skills/figma-explore/SKILL.md
+++ b/.claude/skills/figma-explore/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: figma-explore
+description: Explore a Figma file to discover all pages, components, and component sets using the Figma REST API. Use when you need to list components in a Figma file, find component node IDs for Code Connect, or understand the structure of a design file.
+---
+
+# Skill: Explore Figma Files
+
+This skill provides scripts to explore Figma files via the REST API, bypassing the limitations of the MCP tools which require a specific node ID.
+
+## When to Use This Skill
+
+- User provides a Figma file URL without a specific node ID
+- Need to discover all components in a Figma design system
+- Want to find component node IDs for Code Connect setup
+- Need to understand the page/component structure of a Figma file
+
+## Prerequisites
+
+1. **FIGMA_ACCESS_TOKEN**: Set in `.env` or environment
+   - Get from: https://www.figma.com/developers/api#access-tokens
+   - Required scope: `file_content:read`
+
+2. **Node.js**: Version 18+ (for native fetch)
+
+## The Script: `figma-extract-all.js`
+
+A single script that handles both discovery and full extraction with batched API requests.
+
+**Usage:**
+```bash
+node .claude/skills/figma-explore/figma-extract-all.js <figmaFileUrl> [options]
+```
+
+**Options:**
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--list-only` | Quick discovery only (1 API call) | Full extraction |
+| `--output <dir>` | Output directory for JSON files | `.temp/figma-explore` |
+| `--batch-size <n>` | Components per batch request | 30 |
+| `--delay <ms>` | Delay between batches (rate limiting) | 1000 |
+
+### Quick Discovery (1 API call)
+```bash
+node .claude/skills/figma-explore/figma-extract-all.js <url> --list-only
+```
+Outputs JSON with component names, IDs, and URLs to stdout.
+
+### Full Extraction (batched)
+```bash
+node .claude/skills/figma-explore/figma-extract-all.js <url>
+```
+Writes to `.temp/figma-explore/`:
+- `figma-components-index.json` - Summary index
+- `<component>.json` - Full evidence per component
+
+### API Call Efficiency
+
+| Mode | 45 Components | API Calls |
+|------|---------------|-----------|
+| `--list-only` | 1 call | ✅ Instant |
+| Full extraction | 1 + ⌈45/30⌉ = 3 calls | ✅ Batched |
+
+## Execution Steps
+
+### Step 1: Verify Environment
+
+Before running the script, ensure the token is available:
+
+```bash
+# Check if token is set
+source .env 2>/dev/null
+[ -n "$FIGMA_ACCESS_TOKEN" ] && echo "Token: set" || echo "Token: missing"
+```
+
+If not set:
+1. Create token at https://www.figma.com/developers/api#access-tokens
+2. Add to `.env`: `FIGMA_ACCESS_TOKEN=figd_...`
+
+### Step 2: Run Extraction
+
+**Quick discovery:**
+```bash
+source .env && node .claude/skills/figma-explore/figma-extract-all.js "<figmaUrl>" --list-only
+```
+
+**Full extraction:**
+```bash
+source .env && node .claude/skills/figma-explore/figma-extract-all.js "<figmaUrl>"
+```
+
+### Step 3: Use Results
+
+**Index file** (`.temp/figma-explore/figma-components-index.json`):
+```json
+{
+  "fileName": "Obra shadcn/ui",
+  "fileKey": "MQUbIrlfuM8qnr9XZ7jc82",
+  "totalComponents": 45,
+  "components": [
+    { "name": "Button", "id": "16:1234", "url": "..." }
+  ]
+}
+```
+
+**Component evidence** (`.temp/figma-explore/button.json`):
+```json
+{
+  "componentSetId": "16:1234",
+  "componentName": "Button",
+  "variantProperties": { "Size": ["Small", "Large"] },
+  "componentProperties": [{ "name": "Disabled", "type": "BOOLEAN" }],
+  "textLayers": [{ "name": "Label", "characters": "Button" }],
+  "slotLayers": [{ "name": "Icon", "type": "INSTANCE" }]
+}
+```
+
+### Step 4: Generate Code Connect
+
+Use the evidence files with:
+- The `figma-connect-component` skill
+- Direct Code Connect generation
+- Manual `.figma.tsx` file creation
+
+## Figma REST API Reference
+
+The scripts use these endpoints:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /v1/files/:file_key` | Get entire file structure |
+| `GET /v1/files/:file_key/nodes?ids=:node_ids` | Get specific node details |
+| `GET /v1/files/:file_key/components` | List published components |
+
+## Troubleshooting
+
+### 401/403 Errors
+- Token is invalid or expired
+- Token doesn't have `file_content:read` scope
+- Regenerate at https://www.figma.com/developers/api#access-tokens
+
+### 404 Errors  
+- File key is incorrect
+- You don't have access to the file
+- File has been deleted or moved
+
+### Network Errors
+- Check internet connection
+- Corporate proxy may need HTTP_PROXY/HTTPS_PROXY set

--- a/.claude/skills/figma-explore/figma-extract-all.js
+++ b/.claude/skills/figma-explore/figma-extract-all.js
@@ -1,0 +1,534 @@
+#!/usr/bin/env node
+
+/**
+ * Figma Full Component Extractor
+ * 
+ * Extracts all components from a Figma file with full details in batched requests.
+ * Combines listing + detail fetching into one efficient operation.
+ * 
+ * Usage:
+ *   node figma-extract-all.js <figmaFileUrl> [options]
+ * 
+ * Options:
+ *   --list-only        List components only (1 API call, no details)
+ *   --output <dir>     Output directory for JSON files (default: .figma-components)
+ *   --batch-size <n>   Number of components per batch request (default: 30)
+ *   --delay <ms>       Delay between batch requests in ms (default: 1000)
+ * 
+ * Environment:
+ *   FIGMA_ACCESS_TOKEN - Figma personal access token (required)
+ * 
+ * Output:
+ *   - figma-components-index.json  - Summary of all components
+ *   - <component-name>.json        - Detailed evidence for each component
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Load .env from project root
+const envPath = path.resolve(process.cwd(), '.env');
+if (fs.existsSync(envPath)) {
+  const envContent = fs.readFileSync(envPath, 'utf8');
+  for (const line of envContent.split('\n')) {
+    const match = line.match(/^([^=]+)=(.*)$/);
+    if (match && !process.env[match[1]]) {
+      process.env[match[1]] = match[2].replace(/^["']|["']$/g, '');
+    }
+  }
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const DEFAULT_BATCH_SIZE = 30;  // Figma recommends keeping batches reasonable
+const DEFAULT_DELAY_MS = 1000;  // 1 second between batches to avoid rate limits
+const DEFAULT_OUTPUT_DIR = '.temp/figma-explore';
+
+// Modes
+const MODE_FULL = 'full';      // List + fetch details
+const MODE_LIST = 'list';      // List only (1 API call)
+
+// ============================================================================
+// Utilities
+// ============================================================================
+
+function parseFileKey(input) {
+  if (!input) return null;
+  if (!input.includes('/')) return input;
+  
+  const designMatch = input.match(/figma\.com\/design\/([^\/]+)/);
+  if (designMatch) return designMatch[1];
+  
+  const fileMatch = input.match(/figma\.com\/file\/([^\/]+)/);
+  if (fileMatch) return fileMatch[1];
+  
+  return null;
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const config = {
+    fileUrl: null,
+    fileKey: null,
+    outputDir: DEFAULT_OUTPUT_DIR,
+    batchSize: DEFAULT_BATCH_SIZE,
+    delayMs: DEFAULT_DELAY_MS,
+    mode: MODE_FULL
+  };
+  
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--output' && args[i + 1]) {
+      config.outputDir = args[++i];
+    } else if (arg === '--batch-size' && args[i + 1]) {
+      config.batchSize = parseInt(args[++i], 10);
+    } else if (arg === '--delay' && args[i + 1]) {
+      config.delayMs = parseInt(args[++i], 10);
+    } else if (arg === '--list-only' || arg === '--list') {
+      config.mode = MODE_LIST;
+    } else if (!arg.startsWith('--')) {
+      config.fileUrl = arg;
+      config.fileKey = parseFileKey(arg);
+    }
+  }
+  
+  return config;
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function normalizeComponentName(name) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .replace(/_+/g, '_');
+}
+
+// ============================================================================
+// Figma API
+// ============================================================================
+
+async function figmaRequest(pathname, token) {
+  const response = await fetch(`https://api.figma.com${pathname}`, {
+    method: 'GET',
+    headers: { 'X-Figma-Token': token }
+  });
+  
+  if (!response.ok) {
+    const text = await response.text();
+    
+    // Check for rate limiting
+    if (response.status === 429) {
+      const retryAfter = response.headers.get('Retry-After') || '60';
+      throw new Error(`Rate limited. Retry after ${retryAfter} seconds.`);
+    }
+    
+    if (response.status === 401 || response.status === 403) {
+      throw new Error(
+        `Authentication failed (${response.status})\n` +
+        `Verify FIGMA_ACCESS_TOKEN is set correctly.`
+      );
+    }
+    if (response.status === 404) {
+      throw new Error(`File not found (404)`);
+    }
+    throw new Error(`Figma API error: ${response.status} - ${text}`);
+  }
+  
+  return response.json();
+}
+
+/**
+ * Fetch multiple nodes in a single batched request
+ */
+async function fetchNodesBatch(fileKey, nodeIds, token) {
+  const idsParam = nodeIds.map(id => encodeURIComponent(id)).join(',');
+  const data = await figmaRequest(`/v1/files/${fileKey}/nodes?ids=${idsParam}`, token);
+  return data.nodes || {};
+}
+
+// ============================================================================
+// Component Discovery (from file structure)
+// ============================================================================
+
+function findComponentSets(node, breadcrumbs = [], results = []) {
+  if (!node) return results;
+  
+  const currentPath = [...breadcrumbs];
+  if (node.name && node.type !== 'DOCUMENT') {
+    currentPath.push(node.name);
+  }
+  
+  // Skip hidden components
+  if (node.name && (node.name.startsWith('_') || node.name.startsWith('.'))) {
+    return results;
+  }
+  
+  if (node.type === 'COMPONENT_SET') {
+    results.push({
+      name: node.name,
+      id: node.id,
+      variantCount: node.children ? node.children.length : 0,
+      description: node.description || '',
+      path: currentPath.join(' / ')
+    });
+  }
+  
+  if (node.children) {
+    for (const child of node.children) {
+      findComponentSets(child, currentPath, results);
+    }
+  }
+  
+  return results;
+}
+
+// ============================================================================
+// Component Detail Extraction
+// ============================================================================
+
+function extractVariantProperties(componentSet) {
+  const variantProps = {};
+  
+  if (!componentSet.children) return variantProps;
+  
+  for (const variant of componentSet.children) {
+    if (variant.type !== 'COMPONENT') continue;
+    
+    const parts = variant.name.split(',').map(p => p.trim());
+    for (const part of parts) {
+      const [key, value] = part.split('=').map(s => s.trim());
+      if (key && value) {
+        if (!variantProps[key]) {
+          variantProps[key] = new Set();
+        }
+        variantProps[key].add(value);
+      }
+    }
+  }
+  
+  // Convert sets to arrays and create enum mappings
+  const result = {};
+  const enumMappings = {};
+  
+  for (const [key, values] of Object.entries(variantProps)) {
+    const valuesArray = Array.from(values);
+    result[key] = valuesArray;
+    
+    // Create normalized enum values for code
+    enumMappings[key] = {
+      rawKey: key,
+      normalizedKey: key.charAt(0).toLowerCase() + key.slice(1),
+      values: valuesArray,
+      enums: valuesArray.map(v => v.toLowerCase().replace(/\s+/g, '-'))
+    };
+  }
+  
+  return { variantProperties: result, variantValueEnums: enumMappings };
+}
+
+function extractComponentProperties(componentSet) {
+  const props = [];
+  
+  if (!componentSet.componentPropertyDefinitions) return props;
+  
+  for (const [name, def] of Object.entries(componentSet.componentPropertyDefinitions)) {
+    const cleanName = name.replace(/#\d+:\d+$/, '');
+    props.push({
+      name: cleanName,
+      type: def.type,
+      defaultValue: def.defaultValue,
+      variantOptions: def.variantOptions
+    });
+  }
+  
+  return props;
+}
+
+function findTextLayers(node, depth = 0, maxDepth = 5, results = []) {
+  if (!node || depth > maxDepth) return results;
+  
+  if (node.type === 'TEXT') {
+    results.push({
+      name: node.name,
+      type: 'TEXT',
+      characters: node.characters || ''
+    });
+  }
+  
+  if (node.children) {
+    for (const child of node.children) {
+      findTextLayers(child, depth + 1, maxDepth, results);
+    }
+  }
+  
+  return results;
+}
+
+function findSlotLayers(node, depth = 0, maxDepth = 5, results = []) {
+  if (!node || depth > maxDepth) return results;
+  
+  if (node.type === 'FRAME' || node.type === 'INSTANCE') {
+    const name = (node.name || '').toLowerCase();
+    if (name.includes('slot') || 
+        name.includes('content') ||
+        name.includes('icon') ||
+        name.includes('leading') ||
+        name.includes('trailing') ||
+        name.includes('children')) {
+      results.push({
+        name: node.name,
+        type: node.type
+      });
+    }
+  }
+  
+  if (node.children) {
+    for (const child of node.children) {
+      findSlotLayers(child, depth + 1, maxDepth, results);
+    }
+  }
+  
+  return results;
+}
+
+function extractComponentEvidence(nodeId, document, fileKey) {
+  const { variantProperties, variantValueEnums } = extractVariantProperties(document);
+  
+  const evidence = {
+    schemaVersion: 'figma-component@1',
+    componentSetId: nodeId,
+    componentName: document.name,
+    description: document.description || '',
+    url: `https://www.figma.com/design/${fileKey}?node-id=${nodeId.replace(':', '-')}`,
+    variantProperties,
+    variantValueEnums,
+    componentProperties: extractComponentProperties(document),
+    textLayers: [],
+    slotLayers: [],
+    variants: [],
+    totalVariants: 0
+  };
+  
+  if (document.children) {
+    evidence.totalVariants = document.children.filter(c => c.type === 'COMPONENT').length;
+    
+    // Extract from first variant for text/slot layers
+    const firstVariant = document.children.find(c => c.type === 'COMPONENT');
+    if (firstVariant) {
+      evidence.textLayers = findTextLayers(firstVariant);
+      evidence.slotLayers = findSlotLayers(firstVariant);
+    }
+    
+    // List all variants
+    evidence.variants = document.children
+      .filter(c => c.type === 'COMPONENT')
+      .map(c => ({
+        name: c.name,
+        id: c.id
+      }));
+  }
+  
+  return evidence;
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+async function main() {
+  const config = parseArgs();
+  
+  if (!config.fileKey) {
+    console.error('Usage: node figma-extract-all.js <figmaFileUrl> [options]');
+    console.error('');
+    console.error('Options:');
+    console.error('  --list-only        List components only (1 API call, no details)');
+    console.error('  --output <dir>     Output directory (default: .figma-components)');
+    console.error('  --batch-size <n>   Components per batch request (default: 30)');
+    console.error('  --delay <ms>       Delay between batches in ms (default: 1000)');
+    process.exit(1);
+  }
+  
+  const token = process.env.FIGMA_ACCESS_TOKEN;
+  if (!token) {
+    console.error('Error: FIGMA_ACCESS_TOKEN environment variable is required');
+    process.exit(1);
+  }
+  
+  try {
+    // ========================================================================
+    // Step 1: Fetch file structure
+    // ========================================================================
+    console.error(`\n📁 Fetching Figma file: ${config.fileKey}`);
+    
+    const fileData = await figmaRequest(`/v1/files/${config.fileKey}`, token);
+    
+    console.error(`   File: ${fileData.name}`);
+    console.error(`   Version: ${fileData.version}`);
+    console.error(`   Last Modified: ${fileData.lastModified}`);
+    
+    // ========================================================================
+    // Step 2: Discover all component sets
+    // ========================================================================
+    const pages = fileData.document.children || [];
+    console.error(`\n📑 Pages: ${pages.map(p => p.name).join(', ')}`);
+    
+    const allComponents = [];
+    for (const page of pages) {
+      const components = findComponentSets(page);
+      for (const comp of components) {
+        comp.page = page.name;
+        allComponents.push(comp);
+      }
+    }
+    
+    console.error(`\n🧩 Found ${allComponents.length} component sets`);
+    
+    if (allComponents.length === 0) {
+      console.error('   No components found in file.');
+      process.exit(0);
+    }
+    
+    // ========================================================================
+    // List-only mode: output summary and exit
+    // ========================================================================
+    if (config.mode === MODE_LIST) {
+      const listResult = {
+        fileName: fileData.name,
+        fileKey: config.fileKey,
+        fileUrl: `https://www.figma.com/design/${config.fileKey}`,
+        version: fileData.version,
+        lastModified: fileData.lastModified,
+        totalComponents: allComponents.length,
+        components: allComponents.map(c => ({
+          name: c.name,
+          id: c.id,
+          page: c.page,
+          path: c.path,
+          variantCount: c.variantCount,
+          url: `https://www.figma.com/design/${config.fileKey}?node-id=${c.id.replace(':', '-')}`
+        }))
+      };
+      
+      console.error(`\n✅ List complete! (use without --list-only for full extraction)`);
+      console.log(JSON.stringify(listResult, null, 2));
+      process.exit(0);
+    }
+    
+    // ========================================================================
+    // Step 3: Batch fetch component details
+    // ========================================================================
+    const nodeIds = allComponents.map(c => c.id);
+    const batches = [];
+    
+    for (let i = 0; i < nodeIds.length; i += config.batchSize) {
+      batches.push(nodeIds.slice(i, i + config.batchSize));
+    }
+    
+    console.error(`\n📦 Fetching details in ${batches.length} batch(es) of up to ${config.batchSize}...`);
+    
+    const allNodeData = {};
+    
+    for (let i = 0; i < batches.length; i++) {
+      const batch = batches[i];
+      console.error(`   Batch ${i + 1}/${batches.length}: ${batch.length} components...`);
+      
+      const batchResults = await fetchNodesBatch(config.fileKey, batch, token);
+      Object.assign(allNodeData, batchResults);
+      
+      // Delay between batches (except for last batch)
+      if (i < batches.length - 1) {
+        await sleep(config.delayMs);
+      }
+    }
+    
+    // ========================================================================
+    // Step 4: Extract evidence and write output
+    // ========================================================================
+    console.error(`\n💾 Writing output to ${config.outputDir}/`);
+    
+    // Ensure output directory exists
+    if (!fs.existsSync(config.outputDir)) {
+      fs.mkdirSync(config.outputDir, { recursive: true });
+    }
+    
+    const componentIndex = [];
+    const usedFilenames = new Set();
+    
+    for (const component of allComponents) {
+      const nodeData = allNodeData[component.id];
+      if (!nodeData || !nodeData.document) {
+        console.error(`   ⚠️  Skipping ${component.name}: no data returned`);
+        continue;
+      }
+      
+      const evidence = extractComponentEvidence(
+        component.id,
+        nodeData.document,
+        config.fileKey
+      );
+      
+      // Generate unique filename
+      let filename = normalizeComponentName(component.name);
+      let counter = 1;
+      while (usedFilenames.has(filename)) {
+        filename = `${normalizeComponentName(component.name)}_${counter++}`;
+      }
+      usedFilenames.add(filename);
+      
+      // Write individual component file
+      const componentPath = path.join(config.outputDir, `${filename}.json`);
+      fs.writeFileSync(componentPath, JSON.stringify(evidence, null, 2));
+      
+      // Add to index
+      componentIndex.push({
+        name: component.name,
+        id: component.id,
+        filename: `${filename}.json`,
+        page: component.page,
+        path: component.path,
+        variantCount: evidence.totalVariants,
+        url: evidence.url
+      });
+    }
+    
+    // Write index file
+    const indexData = {
+      schemaVersion: 'figma-component-index@1',
+      fileName: fileData.name,
+      fileKey: config.fileKey,
+      fileUrl: `https://www.figma.com/design/${config.fileKey}`,
+      version: fileData.version,
+      lastModified: fileData.lastModified,
+      exportDate: new Date().toISOString(),
+      totalComponents: componentIndex.length,
+      components: componentIndex
+    };
+    
+    const indexPath = path.join(config.outputDir, 'figma-components-index.json');
+    fs.writeFileSync(indexPath, JSON.stringify(indexData, null, 2));
+    
+    // ========================================================================
+    // Summary
+    // ========================================================================
+    console.error(`\n✅ Complete!`);
+    console.error(`   Components extracted: ${componentIndex.length}`);
+    console.error(`   Index file: ${indexPath}`);
+    console.error(`   Component files: ${config.outputDir}/*.json`);
+    
+    // Output index to stdout for piping
+    console.log(JSON.stringify(indexData, null, 2));
+    
+  } catch (error) {
+    console.error(`\n❌ Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/.claude/skills/figma-implement-component/SKILL.md
+++ b/.claude/skills/figma-implement-component/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: figma-implement-component
+description: Implement React components from Figma designs. Use after figma-design-react has analyzed the design. Delegates to create-react-modlet for folder structure, then adds Figma-specific implementation, stories for each variant, Code Connect mapping, and README with design context.
+---
+
+# Skill: Implement Component from Figma Design
+
+This skill implements React components from analyzed Figma designs. It creates complete modlets with stories matching Figma variants and establishes the foundation for Code Connect and future design syncing.
+
+## When to Use
+
+- After `figma-design-react` skill has analyzed a Figma design
+- User wants to build a component from a Figma URL
+- Creating a new component that should stay in sync with Figma
+
+## What This Skill Does
+
+1. Verifies design analysis exists (or triggers it)
+2. Creates component modlet following project standards
+3. Writes README with Figma source and mapping context
+4. Implements the component matching Figma design precisely
+5. Creates Storybook stories for each Figma variant/state
+6. Creates Code Connect mapping for Figma integration
+7. Verifies tests pass and Storybook renders
+
+## Prerequisites
+
+- Figma design URL (required if design analysis doesn't exist)
+- OR existing design analysis files:
+  - Design context file at `.temp/design-components/{component-name}/design-context.md`
+  - Proposed API file at `.temp/design-components/{component-name}/proposed-api.md`
+
+If design analysis files don't exist, this skill will automatically invoke `figma-design-react` to generate them.
+
+## Workflow Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 0. CREATE TODO LIST - Track all steps systematically           │
+├─────────────────────────────────────────────────────────────────┤
+│ 1. VERIFY AND GENERATE - Check for design analysis files       │
+│    → If missing: Invoke figma-design-react skill                │
+│    → Creates .temp/design-components/{name}/design-context.md   │
+│    → Creates .temp/design-components/{name}/proposed-api.md     │
+├─────────────────────────────────────────────────────────────────┤
+│ 2. CREATE MODLET - Build folder structure using modlet pattern │
+├─────────────────────────────────────────────────────────────────┤
+│ 3. WRITE README - Document Figma source and mapping rationale  │
+├─────────────────────────────────────────────────────────────────┤
+│ 4. CREATE TYPES - Define TypeScript props interface            │
+├─────────────────────────────────────────────────────────────────┤
+│ 5. IMPLEMENT - Build component matching Figma precisely        │
+├─────────────────────────────────────────────────────────────────┤
+│ 6. CREATE STORIES - Story for each Figma variant/state         │
+├─────────────────────────────────────────────────────────────────┤
+│ 7. CODE CONNECT - Create .figma.tsx mapping file               │
+├─────────────────────────────────────────────────────────────────┤
+│ 8. CREATE TESTS - Unit tests for all variants and behaviors    │
+├─────────────────────────────────────────────────────────────────┤
+│ 9. UPDATE EXPORTS - Add to index.ts                             │
+├─────────────────────────────────────────────────────────────────┤
+│ 10. VERIFY - Run tests, check types, confirm Storybook renders │
+├─────────────────────────────────────────────────────────────────┤
+│ 11. PLAYWRIGHT - Visual test Storybook against Figma design    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Table of Contents
+
+### Implementation Steps
+Each step contains detailed instructions and templates:
+
+- [Step 0: Create Todo List](steps/00-todo-setup.md) - Set up systematic tracking with `manage_todo_list`
+- [Step 1: Verify and Generate Design Analysis](steps/01-design-analysis.md) - Check for or create design files
+- [Step 2: Create Modlet Structure](steps/02-modlet-structure.md) - Build component folder via `create-react-modlet` skill
+- [Step 3: Write README with Design Context](steps/03-readme.md) - Document Figma source and mappings
+- [Step 4: Create Types](steps/04-types.md) - Define TypeScript props interface
+- [Step 5: Implement Component](steps/05-implementation.md) - Build component matching Figma exactly
+- [Step 6: Create Stories for Each Variant](steps/06-stories.md) - Storybook stories for all Figma variants
+- [Step 7: Create Code Connect Mapping](steps/07-code-connect.md) - Link component to Figma
+- [Step 8: Create Tests](steps/08-tests.md) - Unit tests for variants and behaviors
+- [Step 9: Create index.ts](steps/09-exports.md) - Export component and types
+- [Step 10: Verify Tests and Storybook](steps/10-verification.md) - Run tests and check visual rendering
+- [Step 11: Playwright Visual Testing](steps/11-playwright.md) - Test Storybook against Figma design
+
+### Reference Materials
+- [Output Files Summary](reference/output-files.md) - Expected folder structure after completion
+- [Quality Checklist](reference/quality-checklist.md) - Verification checklist before marking complete
+
+## How to Use This Skill
+
+1. Start by reading [Step 0: Create Todo List](steps/00-todo-setup.md)
+2. Create a todo list using `manage_todo_list` before implementation
+3. Follow steps 1-11 in order, marking each as in-progress → completed
+4. Use [Quality Checklist](reference/quality-checklist.md) to verify completion
+5. Only provide final summary after all todos are marked completed
+
+This prevents common failures like skipping file creation steps, forgetting Code Connect mapping, or missing verification steps.
+
+## Related Skills
+
+- **figma-design-react**: Run first to analyze Figma and generate proposed API
+- **create-react-modlet**: Defines the modlet folder structure
+- **figma-connect-component**: Detailed Code Connect mapping guidance
+- **figma-component-sync**: Use later to check implementation against Figma changes
+

--- a/.claude/skills/figma-implement-component/reference/output-files.md
+++ b/.claude/skills/figma-implement-component/reference/output-files.md
@@ -1,0 +1,14 @@
+# Output Files Summary
+
+After completion, the modlet should contain:
+
+```
+packages/client/src/components/common/{ComponentName}/
+├── index.ts                      # Re-exports
+├── {ComponentName}.tsx           # Component
+├── {ComponentName}.test.tsx      # Tests
+├── {ComponentName}.stories.tsx   # Stories for each variant
+├── {ComponentName}.figma.tsx     # Code Connect
+├── types.ts                      # TypeScript types
+└── README.md                     # Figma source & mapping
+```

--- a/.claude/skills/figma-implement-component/reference/quality-checklist.md
+++ b/.claude/skills/figma-implement-component/reference/quality-checklist.md
@@ -1,0 +1,28 @@
+# Quality Checklist
+
+Before marking complete, verify all items:
+
+## File Structure
+- [ ] All files from modlet pattern exist
+- [ ] README.md has Figma URL and mapping table
+
+## Design Fidelity
+- [ ] Component matches Figma dimensions exactly
+- [ ] Component matches Figma colors exactly
+- [ ] Typography matches Figma (size, weight, line-height)
+- [ ] Spacing/padding matches Figma
+
+## Stories & Variants
+- [ ] All Figma variants have corresponding stories
+- [ ] Responsive behaviors documented and have stories
+- [ ] Code Connect mapping created
+
+## Unit Tests
+- [ ] Tests pass (`npm run test`)
+- [ ] Types pass (`npm run typecheck`)
+
+## Playwright Visual Testing
+- [ ] Each story tested in Storybook via Playwright MCP
+- [ ] Visual appearance matches Figma design
+- [ ] Interactive behaviors (hover, focus, disabled) work correctly
+- [ ] Any accepted differences documented in README

--- a/.claude/skills/figma-implement-component/steps/00-todo-setup.md
+++ b/.claude/skills/figma-implement-component/steps/00-todo-setup.md
@@ -1,0 +1,183 @@
+# Step 0: Create Todo List
+
+Use `manage_todo_list` to create a checklist before starting implementation.
+
+## For Single Component
+
+```javascript
+manage_todo_list({
+  operation: 'write',
+  todoList: [
+    {
+      id: 1,
+      title: 'Verify and generate design analysis',
+      description: 'Use file_search to check for design-context.md and proposed-api.md. If missing, invoke figma-design-react via runSubagent. Do not proceed without these files.',
+      status: 'not-started'
+    },
+    {
+      id: 2,
+      title: 'Create modlet structure via subagent',
+      description: 'Use runSubagent to invoke create-react-modlet skill for folder structure',
+      status: 'not-started'
+    },
+    {
+      id: 3,
+      title: 'Write README.md with Figma source',
+      description: 'Document Figma URL and design-to-code mapping tables',
+      status: 'not-started'
+    },
+    {
+      id: 4,
+      title: 'Create types.ts with props interface',
+      description: 'Define TypeScript interface from proposed-api.md',
+      status: 'not-started'
+    },
+    {
+      id: 5,
+      title: 'Implement component matching Figma',
+      description: 'Build component with exact dimensions, colors, typography from Figma',
+      status: 'not-started'
+    },
+    {
+      id: 6,
+      title: 'Create stories for all variants',
+      description: 'Story for each Figma variant, size, state, and boolean property',
+      status: 'not-started'
+    },
+    {
+      id: 7,
+      title: 'Create Code Connect mapping',
+      description: 'Write {ComponentName}.figma.tsx with figma.connect()',
+      status: 'not-started'
+    },
+    {
+      id: 8,
+      title: 'Create/update tests',
+      description: 'Add tests for all props, variants, and interactions',
+      status: 'not-started'
+    },
+    {
+      id: 9,
+      title: 'Update index.ts exports',
+      description: 'Export component and types',
+      status: 'not-started'
+    },
+    {
+      id: 10,
+      title: 'Run verification',
+      description: 'Run npm test and verify Storybook renders',
+      status: 'not-started'
+    },
+    {
+      id: 11,
+      title: 'Playwright visual testing',
+      description: 'Use Playwright MCP to test Storybook stories against Figma design and verify interactions',
+      status: 'not-started'
+    }
+  ]
+})
+```
+
+## For Multiple Components (e.g., Button + LinkButton)
+
+```javascript
+manage_todo_list({
+  operation: 'write',
+  todoList: [
+    {
+      id: 1,
+      title: 'Verify and generate design analysis',
+      description: 'Use file_search to check for design-context.md and proposed-api.md. If missing, invoke figma-design-react via runSubagent. Do not proceed without these files.',
+      status: 'not-started'
+    },
+    {
+      id: 2,
+      title: 'Create parent folder and index.ts',
+      description: 'Create packages/client/src/components/common/{parent}/ with barrel export',
+      status: 'not-started'
+    },
+    {
+      id: 3,
+      title: '[Button] Create modlet via subagent',
+      description: 'Create Button/ folder structure',
+      status: 'not-started'
+    },
+    {
+      id: 4,
+      title: '[Button] Write README with Figma source',
+      description: 'Document Button-specific Figma mapping',
+      status: 'not-started'
+    },
+    {
+      id: 5,
+      title: '[Button] Create types and implementation',
+      description: 'Implement Button component',
+      status: 'not-started'
+    },
+    {
+      id: 6,
+      title: '[Button] Create stories',
+      description: 'Stories for Button variants',
+      status: 'not-started'
+    },
+    {
+      id: 7,
+      title: '[Button] Create Code Connect mapping',
+      description: 'Write Button.figma.tsx',
+      status: 'not-started'
+    },
+    {
+      id: 8,
+      title: '[LinkButton] Create modlet via subagent',
+      description: 'Create LinkButton/ folder structure',
+      status: 'not-started'
+    },
+    {
+      id: 9,
+      title: '[LinkButton] Write README with Figma source',
+      description: 'Document LinkButton-specific Figma mapping',
+      status: 'not-started'
+    },
+    {
+      id: 10,
+      title: '[LinkButton] Create types and implementation',
+      description: 'Implement LinkButton component',
+      status: 'not-started'
+    },
+    {
+      id: 11,
+      title: '[LinkButton] Create stories',
+      description: 'Stories for LinkButton variants',
+      status: 'not-started'
+    },
+    {
+      id: 12,
+      title: '[LinkButton] Create Code Connect mapping',
+      description: 'Write LinkButton.figma.tsx',
+      status: 'not-started'
+    },
+    {
+      id: 13,
+      title: 'Run tests for all components',
+      description: 'Verify npm test passes',
+      status: 'not-started'
+    },
+    {
+      id: 14,
+      title: 'Verify all Storybooks',
+      description: 'Check Button and LinkButton stories render correctly',
+      status: 'not-started'
+    }
+    {
+      id: 15,
+      title: 'Playwright visual testing',
+      description: 'Use Playwright MCP to test all stories against Figma design and verify interactions',
+      status: 'not-started'
+    }
+  ]
+})
+```
+
+## Workflow Pattern
+
+Mark each task as `in-progress` before starting it, complete the work, then mark it `completed` immediately. Do not batch completion updates.

--- a/.claude/skills/figma-implement-component/steps/01-design-analysis.md
+++ b/.claude/skills/figma-implement-component/steps/01-design-analysis.md
@@ -1,0 +1,105 @@
+# Step 1: Verify and Generate Design Analysis
+
+You must create or verify these files exist before proceeding to Step 2:
+
+```
+.temp/design-components/{component-name}/
+├── design-context.md    # Raw Figma data
+└── proposed-api.md      # Suggested component API
+```
+
+Calling `mcp_figma_get_design_context` directly is not a substitute for this step. That tool provides raw data but does not create the design analysis files required for implementation.
+
+## Step 1a: Check if Design Analysis Files Exist
+
+Use `file_search` to look for both files:
+- `.temp/design-components/*/design-context.md`
+- `.temp/design-components/*/proposed-api.md`
+
+## If Either File is Missing
+
+Stop and invoke figma-design-react:
+
+1. Request Figma URL from user if not provided
+2. Invoke figma-design-react skill using `runSubagent`:
+   ```javascript
+   runSubagent({
+     description: "Run figma-design-react for {component-name}",
+     prompt: `Read the skill file at .claude/skills/figma-design-react/SKILL.md and follow it to analyze the Figma design at:
+     
+     {figma-url}
+     
+     Create design-context.md and proposed-api.md in .temp/design-components/{component-name}/.
+     
+     Return the full paths of the created files when complete.`
+   })
+   ```
+3. Wait for subagent to complete - do not proceed until files are confirmed created
+4. Use `file_search` again to verify both files now exist
+5. If files still don't exist, STOP and report error to user
+
+## After Both Files Exist
+
+1. Read `design-context.md` to get Figma data and URL
+2. Read `proposed-api.md` to understand props and variants
+3. Check if multiple components are recommended (see Step 1b)
+4. Mark Step 1 as completed in todo list
+
+# Step 1b: Handle Multiple Component Recommendations
+
+The `proposed-api.md` may recommend splitting a Figma component into multiple React components (e.g., `Button` and `LinkButton`). This is common when:
+- A Figma component has fundamentally different visual patterns
+- Different variants serve distinct UX purposes
+- Combining would create invalid prop combinations
+
+## If Multiple Components Are Recommended
+
+1. Mark Step 1b as in-progress in todo list
+
+2. Create a parent folder for the component group:
+   ```
+   packages/client/src/components/common/{parent-name}/
+   ├── {ComponentA}/     # First component modlet
+   ├── {ComponentB}/     # Second component modlet
+   └── index.ts          # Re-exports all components
+   ```
+
+3. Update the todo list to iterate through each component (see Step 0 for multi-component template)
+
+4. Create parent index.ts that re-exports all components:
+   ```typescript
+   // packages/client/src/components/common/button/index.ts
+   export { Button } from './Button';
+   export type { ButtonProps } from './Button';
+   export { LinkButton } from './LinkButton';
+   export type { LinkButtonProps } from './LinkButton';
+   ```
+
+5. Implement each component following Steps 3-9 for each one
+
+6. Mark Step 1b as completed in todo list
+
+## Example Folder Structure for Button + LinkButton
+
+```
+packages/client/src/components/common/button/
+├── index.ts                      # Re-exports Button and LinkButton
+├── Button/
+│   ├── index.ts
+│   ├── Button.tsx
+│   ├── Button.test.tsx
+│   ├── Button.stories.tsx
+│   ├── Button.figma.tsx
+│   ├── types.ts
+│   └── README.md
+└── LinkButton/
+    ├── index.ts
+    ├── LinkButton.tsx
+    ├── LinkButton.test.tsx
+    ├── LinkButton.stories.tsx
+    ├── LinkButton.figma.tsx
+    ├── types.ts
+    └── README.md
+```
+
+If single component: Continue to Step 2 as normal.

--- a/.claude/skills/figma-implement-component/steps/02-modlet-structure.md
+++ b/.claude/skills/figma-implement-component/steps/02-modlet-structure.md
@@ -1,0 +1,51 @@
+# Step 2: Create Modlet Structure
+
+Before starting: Mark Step 2 as `in-progress` in todo list.
+
+Invoke the `create-react-modlet` skill to create the modlet folder structure.
+
+## Use runSubagent to Delegate Modlet Creation
+
+```javascript
+runSubagent({
+  description: "Create modlet for {ComponentName}",
+  prompt: `Read the skill file at .claude/skills/create-react-modlet/SKILL.md and follow it to create a visual modlet for {ComponentName} at:
+  
+  packages/client/src/components/common/{ComponentName}/
+  
+  Create ALL files required for a visual modlet:
+  - index.ts (re-exports)
+  - {ComponentName}.tsx (stub component)
+  - {ComponentName}.test.tsx (basic test)
+  - {ComponentName}.stories.tsx (default story)
+  - types.ts (props interface placeholder)
+  
+  Also create these additional files for Figma integration:
+  - {ComponentName}.figma.tsx (Code Connect mapping placeholder)
+  - README.md (empty, will be filled with Figma context)
+  
+  Return the list of files created.`
+})
+```
+
+After completion: Mark Step 2 as `completed` in todo list.
+
+## Expected Location
+
+The modlet should be created at:
+```
+packages/client/src/components/common/{ComponentName}/
+```
+
+## Expected Folder Structure
+
+```
+{ComponentName}/
+├── index.ts                      # Re-exports
+├── {ComponentName}.tsx           # Component implementation
+├── {ComponentName}.test.tsx      # Tests
+├── {ComponentName}.stories.tsx   # Storybook stories
+├── {ComponentName}.figma.tsx     # Code Connect mapping
+├── types.ts                      # TypeScript interfaces
+└── README.md                     # Figma source & mapping docs
+```

--- a/.claude/skills/figma-implement-component/steps/03-readme.md
+++ b/.claude/skills/figma-implement-component/steps/03-readme.md
@@ -1,0 +1,48 @@
+# Step 3: Write README with Design Context
+
+Before starting: Mark Step 3 as `in-progress` in todo list.
+
+Create `README.md` documenting the Figma-to-code mapping:
+
+## Template
+
+```markdown
+# {ComponentName}
+
+{Brief description of what the component does}
+
+## Figma Source
+
+{Original Figma URL from design-context.md}
+
+## Accepted Design Differences
+
+| Category | Figma | Implementation | File | Reason |
+|----------|-------|----------------|------|--------|
+| Example | Fixed 36px | Auto height | ComponentName.tsx | Flexible content |
+
+## Design-to-Code Mapping
+
+### Variant Mappings
+
+| Figma Variant | Figma Value | React Prop | React Value | Notes |
+|---------------|-------------|------------|-------------|-------|
+| Size | Small | `size` | `'sm'` | Height 32px |
+| Size | Medium | `size` | `'md'` | Height 40px (default) |
+
+### Property Mappings
+
+| Figma Property | Type | React Prop | Notes |
+|----------------|------|------------|-------|
+| Has Icon | Boolean | `icon?: ReactNode` | Renders icon when provided |
+| Label | Text | `children` | - |
+
+### Excluded Properties (CSS/Internal)
+
+| Figma Property | Handling | Reason |
+|----------------|----------|--------|
+| State: Hover | Tailwind `hover:` | Pseudo-state |
+| State: Focused | Tailwind `focus-visible:` | Pseudo-state |
+```
+
+After completion: Mark Step 3 as `completed` in todo list.

--- a/.claude/skills/figma-implement-component/steps/04-types.md
+++ b/.claude/skills/figma-implement-component/steps/04-types.md
@@ -1,0 +1,51 @@
+# Step 4: Create Types
+
+Before starting: Mark Step 4 as `in-progress` in todo list.
+
+Create `types.ts` based on `proposed-api.md`:
+
+## Template
+
+```typescript
+export interface {ComponentName}Props {
+  /**
+   * Size variant
+   * @default 'md'
+   * @figma Variant: Size
+   */
+  size?: 'sm' | 'md' | 'lg';
+  
+  /**
+   * Visual variant
+   * @default 'primary'
+   * @figma Variant: Type
+   */
+  variant?: 'primary' | 'secondary';
+  
+  /**
+   * Disabled state
+   * @default false
+   * @figma Boolean: Disabled
+   */
+  disabled?: boolean;
+  
+  /**
+   * Optional leading icon
+   * @figma Instance: Icon (when Has Icon = true)
+   */
+  icon?: React.ReactNode;
+  
+  /**
+   * Button content
+   * @figma Text: Label
+   */
+  children: React.ReactNode;
+  
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+}
+```
+
+After completion: Mark Step 4 as `completed` in todo list.

--- a/.claude/skills/figma-implement-component/steps/05-implementation.md
+++ b/.claude/skills/figma-implement-component/steps/05-implementation.md
@@ -1,0 +1,60 @@
+# Step 5: Implement Component
+
+Before starting: Mark Step 5 as `in-progress` in todo list.
+
+Create `{ComponentName}.tsx` matching Figma design precisely:
+
+## Implementation Checklist
+
+1. Load design context - Re-read `design-context.md` for exact values
+2. Match dimensions - Use exact spacing, sizes from Figma
+3. Match colors - Use Tailwind classes or CSS variables
+4. Match typography - Font size, weight, line height
+5. Implement all variants - Handle all prop combinations
+6. Use Tailwind - Apply styles with Tailwind classes and `cn()` utility
+
+## Template
+
+```tsx
+import { cn } from '@/lib/utils';
+import type { ComponentNameProps } from './types';
+
+const sizeClasses = {
+  sm: 'h-8 px-3 text-sm',
+  md: 'h-10 px-4 text-base',
+  lg: 'h-12 px-6 text-lg',
+} as const;
+
+const variantClasses = {
+  primary: 'bg-primary text-primary-foreground hover:bg-primary/90',
+  secondary: 'bg-transparent text-primary border border-primary hover:bg-primary/10',
+} as const;
+
+export function ComponentName({
+  size = 'md',
+  variant = 'primary',
+  disabled = false,
+  icon,
+  children,
+  className,
+}: ComponentNameProps) {
+  return (
+    <button
+      className={cn(
+        'inline-flex items-center justify-center gap-2 rounded font-semibold transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        'disabled:opacity-50 disabled:cursor-not-allowed',
+        sizeClasses[size],
+        variantClasses[variant],
+        className
+      )}
+      disabled={disabled}
+    >
+      {icon && <span className="inline-flex shrink-0">{icon}</span>}
+      <span>{children}</span>
+    </button>
+  );
+}
+```
+
+After completion: Mark Step 5 as `completed` in todo list.

--- a/.claude/skills/figma-implement-component/steps/06-stories.md
+++ b/.claude/skills/figma-implement-component/steps/06-stories.md
@@ -1,0 +1,98 @@
+# Step 6: Create Stories for Each Variant
+
+Before starting: Mark Step 6 as `in-progress` in todo list.
+
+Create `{ComponentName}.stories.tsx` with a story for **every Figma variant**:
+
+## Template
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { ComponentName } from './ComponentName';
+
+const meta: Meta<typeof ComponentName> = {
+  component: ComponentName,
+  title: 'Common/ComponentName',
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://figma.com/design/...?node-id=...', // From design-context.md
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ComponentName>;
+
+// Default state (matches Figma default)
+export const Default: Story = {
+  args: {
+    children: 'Button Label',
+  },
+};
+
+// Size variants
+export const Small: Story = {
+  args: {
+    size: 'sm',
+    children: 'Small Button',
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    size: 'md',
+    children: 'Medium Button',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: 'lg',
+    children: 'Large Button',
+  },
+};
+
+// Type variants
+export const Primary: Story = {
+  args: {
+    variant: 'primary',
+    children: 'Primary',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    variant: 'secondary',
+    children: 'Secondary',
+  },
+};
+
+// Boolean properties
+export const WithIcon: Story = {
+  args: {
+    icon: <span>★</span>,
+    children: 'With Icon',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    children: 'Disabled',
+  },
+};
+
+// Responsive stories (if Figma has responsive designs)
+export const Mobile: Story = {
+  args: {
+    children: 'Mobile View',
+  },
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+  },
+};
+```
+
+After completion: Mark Step 6 as `completed` in todo list.

--- a/.claude/skills/figma-implement-component/steps/07-code-connect.md
+++ b/.claude/skills/figma-implement-component/steps/07-code-connect.md
@@ -1,0 +1,44 @@
+# Step 7: Create Code Connect Mapping
+
+Before starting: Mark Step 7 as `in-progress` in todo list.
+
+Create `{ComponentName}.figma.tsx` following `figma-connect-component` skill:
+
+## Template
+
+```tsx
+import figma from '@figma/code-connect';
+import { ComponentName } from './ComponentName';
+
+figma.connect(ComponentName, 'https://figma.com/design/...?node-id=...', {
+  props: {
+    size: figma.enum('Size', {
+      Small: 'sm',
+      Medium: 'md',
+      Large: 'lg',
+    }),
+    variant: figma.enum('Type', {
+      Primary: 'primary',
+      Secondary: 'secondary',
+    }),
+    disabled: figma.boolean('Disabled'),
+    children: figma.textContent('Label'),
+    icon: figma.boolean('Has Icon', {
+      true: figma.instance('Icon'),
+      false: undefined,
+    }),
+  },
+  example: ({ size, variant, disabled, children, icon }) => (
+    <ComponentName
+      size={size}
+      variant={variant}
+      disabled={disabled}
+      icon={icon}
+    >
+      {children}
+    </ComponentName>
+  ),
+});
+```
+
+After completion: Mark Step 7 as `completed` in todo list.

--- a/.claude/skills/figma-implement-component/steps/08-tests.md
+++ b/.claude/skills/figma-implement-component/steps/08-tests.md
@@ -1,0 +1,57 @@
+# Step 8: Create Tests
+
+Before starting: Mark Step 8 as `in-progress` in todo list.
+
+Create `{ComponentName}.test.tsx`:
+
+## Template
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ComponentName } from './ComponentName';
+
+describe('ComponentName', () => {
+  it('renders with default props', () => {
+    render(<ComponentName>Click me</ComponentName>);
+    expect(screen.getByText('Click me')).toBeInTheDocument();
+  });
+
+  it('renders with size="sm"', () => {
+    render(<ComponentName size="sm">Small</ComponentName>);
+    expect(screen.getByRole('button')).toHaveClass('h-8');
+  });
+
+  it('renders with size="lg"', () => {
+    render(<ComponentName size="lg">Large</ComponentName>);
+    expect(screen.getByRole('button')).toHaveClass('h-12');
+  });
+
+  it('renders with variant="secondary"', () => {
+    render(<ComponentName variant="secondary">Secondary</ComponentName>);
+    expect(screen.getByRole('button')).toHaveClass('border');
+  });
+
+  it('renders disabled state', () => {
+    render(<ComponentName disabled>Disabled</ComponentName>);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('renders with icon', () => {
+    render(
+      <ComponentName icon={<span data-testid="icon">★</span>}>
+        With Icon
+      </ComponentName>
+    );
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    render(<ComponentName className="custom-class">Button</ComponentName>);
+    expect(screen.getByRole('button')).toHaveClass('custom-class');
+  });
+});
+```
+
+After completion: Mark Step 8 as `completed` in todo list.

--- a/.claude/skills/figma-implement-component/steps/09-exports.md
+++ b/.claude/skills/figma-implement-component/steps/09-exports.md
@@ -1,0 +1,14 @@
+# Step 9: Create index.ts
+
+Before starting: Mark Step 9 as `in-progress` in todo list.
+
+Create `index.ts` with re-exports:
+
+## Template
+
+```typescript
+export { ComponentName } from './ComponentName';
+export type { ComponentNameProps } from './types';
+```
+
+After completion: Mark Step 9 as `completed` in todo list.

--- a/.claude/skills/figma-implement-component/steps/10-verification.md
+++ b/.claude/skills/figma-implement-component/steps/10-verification.md
@@ -1,0 +1,45 @@
+# Step 10: Verify Tests and Storybook
+
+Before starting: Mark Step 10 as `in-progress` in todo list.
+
+Run verification commands from project root:
+
+## Commands
+
+```bash
+# Run tests
+npm run test
+
+# Type check
+npm run typecheck
+
+# Start Storybook
+npm run storybook
+```
+
+## Tell the User What to Verify
+
+```
+Implementation complete!
+
+## Verify in Storybook
+
+Run `npm run storybook` and check these stories:
+
+Common/ComponentName
+  - Default
+  - Small
+  - Medium  
+  - Large
+  - Primary
+  - Secondary
+  - WithIcon
+  - Disabled
+
+Each story should match its corresponding Figma variant.
+
+## Figma URL for comparison
+{original Figma URL}
+```
+
+After completion: Mark Step 10 as `completed` in todo list.

--- a/.claude/skills/figma-implement-component/steps/11-playwright.md
+++ b/.claude/skills/figma-implement-component/steps/11-playwright.md
@@ -1,0 +1,51 @@
+# Step 11: Playwright Visual Testing with MCP
+
+Before starting: Mark Step 11 as `in-progress` in todo list.
+
+Use Playwright MCP tools to verify each Storybook story matches the Figma design visually and behaviorally.
+
+## Prerequisites
+
+- Storybook running (start with `npm run storybook`)
+- Figma screenshot from `mcp_figma_get_screenshot` for reference
+
+## Test Each Story
+
+For **every story** in the component's `.stories.tsx` file:
+
+1. Navigate to the story URL: `{storybook-url}/iframe.html?id={story-id}&viewMode=story`
+2. Take a snapshot to get the component structure and element references
+3. Verify visually that the rendered component matches the corresponding Figma variant
+4. Test interactions appropriate to the story
+
+## What to Verify
+
+Verify visual and interactive aspects based on the component. Examples:
+
+- **Visual**: Layout, colors, typography, spacing match Figma
+- **Hover**: Background/border changes on hover
+- **Focus**: Focus ring visible with correct styling
+- **Disabled**: Reduced opacity, cursor change, no interaction
+- **Sizing**: Each size variant matches Figma dimensions
+
+## Component-Specific Behaviors
+
+Beyond visual states, test interactive behaviors appropriate to the component. Examples:
+
+- **Select/Dropdown**: Click opens menu, selecting item closes menu and updates value
+- **Accordion**: Click expands/collapses content
+- **Modal/Dialog**: Opens on trigger, closes on backdrop click or close button
+- **Tabs**: Clicking tab switches content
+
+Determine what behaviors to test based on the component's purpose and the Figma design.
+
+## Report Results
+
+After testing all stories, document:
+- Stories that match Figma
+- Any accepted visual differences (add to README "Accepted Design Differences")
+- Issues found that need fixing
+
+After completion: Mark Step 11 as `completed` in todo list.
+
+Final step: Provide summary to user only after all todos are marked completed.

--- a/.claude/skills/validate-implementation/SKILL.md
+++ b/.claude/skills/validate-implementation/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: validate-implementation
+description: Validate implementations for runtime errors and proper functionality. Use when reviewing implementations, syncing designs, or auditing before committing code.
+---
+
+# Skill: Validate Implementation
+
+This skill validates code implementations before marking features complete to catch runtime errors, test failures, and browser console issues.
+
+## When to Use
+
+Use before committing feature implementations, especially:
+- UI components using Dialog, Modal, Select, or Form components
+- Features from Figma designs or Jira tickets
+- After completing any feature implementation
+- Before creating pull requests
+
+## What This Skill Does
+
+1. Runs static analysis (TypeScript and ESLint)
+2. Runs automated test suite
+3. Uses Playwright MCP to validate implementation in the browser
+4. Checks browser console for runtime errors and warnings
+
+## Step 0: Create Validation Todo List
+
+Use `manage_todo_list` to create a checklist before starting validation.
+
+```javascript
+manage_todo_list({
+  todoList: [
+    {
+      id: 1,
+      title: 'Run TypeScript type checking',
+      status: 'not-started'
+    },
+    {
+      id: 2,
+      title: 'Run ESLint checks',
+      status: 'not-started'
+    },
+    {
+      id: 3,
+      title: 'Run unit tests',
+      status: 'not-started'
+    },
+    {
+      id: 4,
+      title: 'Activate Playwright MCP tools',
+      status: 'not-started'
+    },
+    {
+      id: 5,
+      title: 'Navigate to feature page',
+      status: 'not-started'
+    },
+    {
+      id: 6,
+      title: 'Take accessibility snapshot',
+      status: 'not-started'
+    },
+    {
+      id: 7,
+      title: 'Test user interactions',
+      status: 'not-started'
+    },
+    {
+      id: 8,
+      title: 'Verify expected behavior',
+      status: 'not-started'
+    },
+    {
+      id: 9,
+      title: 'Check browser console messages',
+      status: 'not-started'
+    },
+    {
+      id: 10,
+      title: 'Document validation results',
+      status: 'not-started'
+    }
+  ]
+})
+```
+
+Mark each task as `in-progress` before starting it, complete the work, then mark it `completed` immediately. Do not batch completion updates.
+
+## Validation Steps
+
+### 1. Static Analysis
+
+Run TypeScript and linting checks:
+```bash
+npm run typecheck
+npm run lint
+```
+
+Fix any errors before proceeding.
+
+### 2. Automated Tests
+
+Run unit tests:
+```bash
+npm test
+```
+
+Fix any test failures before proceeding.
+
+### 3. Playwright MCP Browser Validation
+
+Activate Playwright MCP tools and validate the feature in the browser:
+
+1. Activate web interaction tools if not already available
+2. Navigate to the feature page
+3. Interact with the implementation (click, type, select, etc.)
+4. Verify expected behavior occurs
+5. Document any issues found
+
+Example workflow:
+```
+1. Navigate to feature page
+2. Take accessibility snapshot to understand page structure
+3. Perform user interactions (click buttons, fill forms, etc.)
+4. Verify state changes and UI updates
+5. Take screenshot if needed for documentation
+```
+
+### 4. Browser Console Check
+
+Check console for errors and warnings:
+
+1. Use Playwright MCP `mcp_playwright_browser_console_messages` with level "info"
+2. Review output for:
+   - Errors (red): Critical issues that must be fixed
+   - Warnings (yellow): Issues that should be addressed
+   - Unexpected logs: Debug statements that should be removed
+3. Fix any errors found before proceeding
+
+## Quick Checklist
+
+Complete steps in order. Cannot proceed to next step until previous step is documented:
+
+```markdown
+- [ ] npm run typecheck passes
+- [ ] npm run lint passes
+- [ ] npm test passes
+- [ ] Playwright MCP browser validation completed:
+      Feature page: ___
+      User interactions tested: ___
+      Expected behavior verified: ___
+- [ ] Browser console checked via Playwright MCP
+- [ ] Browser console output documented:
+      Errors (red): ___
+      Warnings (yellow): ___
+- [ ] Zero browser console errors
+```
+
+Validation is complete only when all items above are checked in sequence.
+
+## Example Usage
+
+### Validating a Dialog Component
+
+```markdown
+Validation for FilterDialog component:
+
+- [x] npm run typecheck passes
+- [x] npm run lint passes
+- [x] npm test passes
+- [x] Playwright MCP browser validation completed
+- [x] Browser console checked via Playwright MCP
+- [x] Browser console output documented:
+      Errors (red): 0
+      Warnings (yellow): 0
+- [x] Zero browser console errors
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,141 @@
+# carton-case-management Development Guidelines
+
+## Skills
+
+Before implementing any feature:
+1. Review the skills table below and read relevant documentation in `.claude/skills/`
+2. Apply skills that match your task (e.g., component-reuse before creating UI)
+3. Follow skill workflows to prevent common mistakes
+
+This project uses Agent Skills for specialized workflows. See `.claude/skills/`:
+
+| Skill | Purpose | When to Use |
+|-------|---------|-------------|
+| `component-reuse` | Ensure existing UI components are reused before creating new ones | Before implementing any UI from Figma, tickets, or mockups |
+| `validate-implementation` | Validate implementations for runtime errors, accessibility, and API compliance | Before marking any feature complete or committing code |
+| `figma-implement-component` | Implement React components from Figma designs | After component-reuse confirms no existing component, use to build new components from Figma |
+| `figma-design-react` | Design React components from Figma files | When analyzing Figma designs to propose component architecture and props API |
+| `figma-component-sync` | Check React components against Figma design source | When reviewing implementations, syncing designs, or auditing visual accuracy |
+| `figma-connect-component` | Generate Figma Code Connect mapping for components | When linking React components to their Figma counterparts |
+| `figma-connect-shadcn` | Connect shadcn/ui components to Figma | After adding shadcn components via `npx shadcn@latest add` |
+| `figma-explore` | Explore Figma files to discover pages and components | When you need to list components in a Figma file or find component node IDs |
+| `create-react-modlet` | Create React components following the modlet pattern | When creating any component in `packages/client/src/components/` |
+| `cross-package-types` | Type flow between shared, server, and client packages | When working with types across package boundaries |
+| `create-skill` | How to create new Agent Skills for this project | When asked to document a workflow or teach Claude a new capability |
+
+## Package-Specific Instructions
+
+Each package has detailed instructions in its own `CLAUDE.md` file:
+
+| Package | CLAUDE.md Location | Purpose |
+|---------|-------------------|---------|
+| `@carton/shared` | `packages/shared/CLAUDE.md` | Prisma schema, generated types, browser-safe utilities |
+| `@carton/server` | `packages/server/CLAUDE.md` | tRPC router, API definitions, database operations |
+| `@carton/client` | `packages/client/CLAUDE.md` | React components, UI, tRPC client usage |
+
+## Active Technologies
+- TypeScript 5.x, React 18.3.x + Shadcn UI components (Input, Select, Button), Radix UI primitives, Lucide icons, Tailwind CSS, Zod (validation)
+- TypeScript 5.x / Node.js 22+ + React 18, tRPC 11, @tanstack/react-query 5, Vite 6, Prisma (ORM)
+
+## Project Structure
+
+```text
+packages/
+  client/   # React frontend
+  server/   # Express/tRPC backend
+  shared/   # Shared types, Prisma schema, utilities
+```
+
+## Commands
+
+### Running Tests
+- **Unit Tests**: `npm test` - Runs all unit tests across workspaces (client, server, shared)
+- **E2E Tests**: `npm run test:e2e` - Runs Playwright end-to-end tests
+- **E2E Tests (UI mode)**: `npm run test:e2e:watch` - Opens Playwright UI for interactive test debugging
+- **Linting**: `npm run lint` - Runs ESLint across all packages
+- **Type Checking**: `npm run typecheck` - Runs TypeScript type checking
+
+### Before Submitting Code
+Always ensure all tests pass before committing:
+```bash
+npm test && npm run test:e2e && npm run lint
+```
+
+## Code Style
+
+TypeScript 5.x / Node.js 22+: Follow standard conventions
+
+## Coding Standards
+
+- When creating new React files ensure to follow the modlet pattern in `packages/client/CLAUDE.md`.
+- No tsx or ts files should have inline comments.
+- All styling should be done using Tailwind CSS classes in an external CSS file.
+- Responsive designing should be implemented using Tailwind CSS utilities.
+- Extract complex logic into custom hooks when it can be reused or when it bloats the component file.
+
+### Component Architecture
+
+- **Component Structure**: Follow the recursive modlet pattern (as demonstrated by CaseDetails component)
+- **Component Testing & Documentation**:
+  - Every component must have accompanying tests (`.test.tsx` files)
+  - Every component should have Storybook stories (`.stories.tsx` files) for documentation and visual testing
+  - Tests should cover main functionality, edge cases, and user interactions
+- **Custom Hooks - when**:
+  - Component has >3 pieces of related state
+  - Logic involves complex calculations/transformations
+  - Logic could be reused elsewhere
+  - Component file exceeds ~100 lines
+  - Examples: `useCaseFilters`, `useFormValidation`, `useDebounce`
+- **Shadcn UI Components**:
+  - Always prioritize using Shadcn UI components over native HTML elements (e.g., use Shadcn Select instead of `<select>`, Shadcn Input instead of `<input>`, etc.)
+  - If a needed component is not available, install the Shadcn equivalent using `npx shadcn@latest add [component-name]`
+  - Shadcn components should be installed to `packages/client/src/components/ui/` directory and exported via `packages/client/src/components/ui/index.ts`
+- **Custom Components**: If a custom component must be built on top of underlying Shadcn components (e.g., EditableSelect, ConfirmationDialog), it should go in `packages/client/src/components/common/`
+- **Domain Wrapper Components**: When using generic/common components in a specific domain context:
+  - Create a domain-specific wrapper component in the domain's `components/` folder
+  - The wrapper encapsulates domain logic (hooks, state management, data fetching)
+  - The wrapper passes domain data to the generic component
+  - Example structure:
+    ```
+    components/common/GenericComponent/        # Generic, reusable
+    components/FeatureName/
+      components/FeatureGenericComponent/      # Domain wrapper
+    ```
+  - Example implementation:
+    ```tsx
+    // Domain wrapper
+    export function FeatureGenericComponent({ open, onOpenChange }) {
+      const { data, handleAction, handleClear } = useFeatureData();
+      return (
+        <GenericComponent
+          open={open}
+          onOpenChange={onOpenChange}
+          data={data}
+          onAction={handleAction}
+          onClear={handleClear}
+        />
+      );
+    }
+    ```
+  - Benefits: Generic components stay reusable, domain logic stays in domain folders, easier testing, clear separation of concerns
+
+### UX Patterns
+
+- **Creating**: Use dedicated create pages (not modals) for creating new entities
+- **Editing**: Implement "click to edit" functionality on view pages with inline editing
+- **Deleting**: Always use a confirmation modal (ConfirmationDialog) before deleting entities
+
+### Data Layer
+
+- **Prisma Schema in Shared**: Prisma schema lives in `packages/shared/prisma/schema.prisma` - the data model is a shared concern
+- **Database Operations in Server**: Database file (`dev.db`), seed script, and constants live in `packages/server/db/`
+- **Prisma Client Import**: Server imports Prisma Client from `@carton/shared`, e.g., `import { prisma } from '@carton/shared'`
+- **Zod Schemas from Prisma**: Use auto-generated Zod schemas from `@carton/shared` for validation - do not manually duplicate Prisma enums
+- **Database Commands** (all run from project root):
+  - `npm run db:generate` - Generate Prisma Client and Zod types
+  - `npm run db:push` - Push schema changes to the database
+  - `npm run db:seed` - Seed the database with test data
+  - `npm run db:setup` - Combined push + seed (use for initial setup or reset)
+  - `npm run db:studio` - Open Prisma Studio to browse data
+- **Environment Config**: Single `.env` file at project root with `DATABASE_URL` pointing to `packages/server/db/dev.db`
+- **Cascading Deletes**: Always configure cascading deletes (`onDelete: Cascade`) in Prisma schema when an entity has related data that should be removed when the parent is deleted

--- a/packages/client/CLAUDE.md
+++ b/packages/client/CLAUDE.md
@@ -1,0 +1,423 @@
+# @carton/client Package Instructions
+
+This package contains the React frontend application.
+
+## Package Purpose
+
+- **React Components**: UI components following modlet pattern
+- **tRPC Client**: Type-safe API calls
+- **Pages**: Route-level components
+- **Styling**: Tailwind CSS with Shadcn UI components
+
+## Directory Structure
+
+```
+packages/client/
+├── src/
+│   ├── main.tsx           # React entry point
+│   ├── App.tsx            # Root component with routing
+│   ├── index.css          # Global styles
+│   ├── components/
+│   │   ├── obra/          # Obra UI components
+│   │   ├── common/        # Reusable custom components
+│   │   ├── CaseList/      # Feature components (modlet pattern)
+│   │   ├── CaseDetails/
+│   │   └── Header/
+│   ├── pages/
+│   │   ├── CasePage/
+│   │   └── CreateCasePage/
+│   └── lib/
+│       ├── trpc.tsx       # tRPC client setup
+│       └── utils.ts       # Utility functions
+├── public/
+├── package.json
+├── vite.config.ts
+└── tailwind.config.js
+```
+
+## Naming Conventions
+
+- **PascalCase** for component folders: `EditableTitle/`, `CaseList/`, `Header/`
+- **kebab-case** for grouping/utility folders (non-components): `inline-edit/`, `date-utils/`
+- **lowercase** for standard folders: `components/`, `common/`, `lib/`, `pages/`
+
+Example structure with grouping folder:
+```
+components/
+  common/
+    inline-edit/          # grouping folder (kebab-case)
+      EditableTitle/      # component folder (PascalCase)
+      EditableSelect/     # component folder (PascalCase)
+```
+
+## Component Pattern (Modlet)
+
+Each feature component follows the modlet pattern:
+
+```
+ComponentName/
+├── ComponentName.tsx      # Main component
+├── ComponentName.test.tsx # Tests
+├── ComponentName.stories.tsx # Storybook stories
+├── index.ts               # Public exports
+├── types.ts               # TypeScript types
+└── components/            # Sub-components
+    └── SubComponent/
+```
+
+## Import Rules
+
+### From @carton/shared/client (Browser-Safe)
+```typescript
+import { 
+  formatCaseNumber, 
+  CASE_STATUS_OPTIONS,
+  type CaseStatus 
+} from '@carton/shared/client';
+```
+
+### From @carton/server (Type-Only)
+```typescript
+import type { AppRouter } from '@carton/server';
+import type { inferRouterOutputs } from '@trpc/server';
+```
+
+### ❌ NEVER Import
+```typescript
+// WRONG - breaks browser builds
+import { prisma } from '@carton/shared';
+import { something } from '@carton/server'; // non-type import
+```
+
+## Type Inference Pattern
+
+Create component types by inferring from AppRouter:
+
+```typescript
+// types.ts
+import type { inferRouterOutputs } from '@trpc/server';
+import type { AppRouter } from '@carton/server';
+
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+
+// Infer types from API responses
+export type CaseListItem = RouterOutputs['case']['list'][number];
+export type CaseDetail = RouterOutputs['case']['getById'];
+
+// Use in props
+export interface CaseListProps {
+  cases?: CaseListItem[];
+  onCaseSelect?: (caseItem: CaseListItem) => void;
+}
+```
+
+This ensures types always match what the API returns (including Date → string serialization).
+
+## tRPC Usage
+
+### Query
+```typescript
+import { trpc } from '@/lib/trpc';
+
+function CaseList() {
+  const { data: cases, isLoading } = trpc.case.list.useQuery();
+  
+  if (isLoading) return <Spinner />;
+  return <ul>{cases?.map(c => <li key={c.id}>{c.title}</li>)}</ul>;
+}
+```
+
+### Mutation
+```typescript
+function CreateCase() {
+  const utils = trpc.useUtils();
+  const createCase = trpc.case.create.useMutation({
+    onSuccess: () => {
+      utils.case.list.invalidate();
+    },
+  });
+  
+  const handleSubmit = (data: CreateCaseInput) => {
+    createCase.mutate(data);
+  };
+}
+```
+
+
+## Styling
+
+Use Tailwind CSS classes. Put custom styles in external CSS files, not inline.
+
+```tsx
+// ✅ Good - Tailwind classes
+<div className="flex items-center gap-4 p-4">
+
+// ❌ Bad - inline styles
+<div style={{ display: 'flex', alignItems: 'center' }}>
+```
+
+## Testing
+
+Each component should have tests:
+
+```typescript
+// ComponentName.test.tsx
+import { render, screen } from '@testing-library/react';
+import { ComponentName } from './ComponentName';
+
+describe('ComponentName', () => {
+  it('renders correctly', () => {
+    render(<ComponentName />);
+    expect(screen.getByText('Expected')).toBeInTheDocument();
+  });
+});
+```
+
+Run tests: `npm run test:client`
+
+## Storybook
+
+Each component should have stories:
+
+```typescript
+// ComponentName.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { ComponentName } from './ComponentName';
+
+const meta: Meta<typeof ComponentName> = {
+  component: ComponentName,
+};
+
+export default meta;
+type Story = StoryObj<typeof ComponentName>;
+
+export const Default: Story = {
+  args: {
+    // default props
+  },
+};
+```
+
+Run Storybook: `npm run storybook`
+
+## UX Patterns
+
+- **Create**: Dedicated pages (not modals)
+- **Edit**: Click-to-edit inline on view pages
+- **Delete**: Always use ConfirmationDialog
+
+## Adding a New Feature Component
+
+1. Create directory: `src/components/FeatureName/`
+2. Create files following modlet pattern
+3. Export from `index.ts`
+4. Create types in `types.ts` using AppRouter inference
+5. Add tests and stories
+
+---
+
+## User Experience Guidelines
+
+**Canonical Reference:** [CasePage](../../packages/client/src/pages/CasePage) implementation
+
+### 1. Sidebar Lists
+
+**Reference:** [CaseList.tsx](../../packages/client/src/components/CaseList/CaseList.tsx)
+
+#### Required Elements
+- Create button at top: `navigate('/entity/new')`
+- Width: `lg:w-[200px]`
+- Active state: Compare `activeId` from `useParams()` with item id
+- Active styling: `bg-[#e8feff]`
+- Hover styling: `hover:bg-gray-100`
+- Truncate long text: `truncate` class
+- Include loading/error/empty states (see section 6)
+
+#### Mobile
+- Hide on mobile: `hidden lg:block`
+- Show in Sheet overlay with `onCaseClick` callback to close
+
+---
+
+### 2. Inline Editing
+
+#### Components
+- **Single-line text:** [EditableTitle](../../packages/client/src/components/common/EditableTitle/EditableTitle.tsx)
+- **Dropdowns:** [EditableSelect](../../packages/client/src/components/common/EditableSelect/EditableSelect.tsx)
+- **Multi-line text:** Custom with Textarea + Save/Cancel buttons
+
+#### Usage
+```tsx
+// Title/heading
+<EditableTitle value={data.title} onSave={handleSave} isLoading={isPending} />
+
+// Dropdown - inline mode
+<EditableSelect value={data.field} options={OPTIONS} onChange={handleChange} />
+
+// Dropdown - always editing (for badges)
+<EditableSelect value={data.status} options={OPTIONS} onChange={handleChange} alwaysEditing />
+
+// Textarea
+{!editing ? <p onClick={() => setEditing(true)}>{text}</p> : <Textarea with Save/Cancel />}
+```
+
+#### Mutation Pattern
+```tsx
+const mutation = trpc.entity.update.useMutation({
+  onMutate: async (variables) => {
+    await utils.entity.getById.cancel({ id });
+    const previous = utils.entity.getById.getData({ id });
+    if (previous) utils.entity.getById.setData({ id }, { ...previous, ...variables });
+    return { previous };
+  },
+  onSuccess: () => {
+    utils.entity.getById.invalidate({ id });
+    utils.entity.list.invalidate();
+  },
+  onError: (err, vars, context) => {
+    if (context?.previous) utils.entity.getById.setData({ id }, context.previous);
+  },
+});
+```
+
+---
+
+### 3. Delete with Confirmation
+
+**Reference:** [CaseInformation.tsx](../../packages/client/src/components/CaseDetails/components/CaseInformation/CaseInformation.tsx), [ConfirmationDialog.tsx](../../packages/client/src/components/common/ConfirmationDialog/ConfirmationDialog.tsx)
+
+#### Pattern
+```tsx
+const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+const deleteEntity = trpc.entity.delete.useMutation({
+  onSuccess: () => {
+    utils.entity.list.invalidate();
+    navigate('/entities/');
+  },
+});
+
+// Trigger (usually in DropdownMenu)
+<DropdownMenuItem onClick={() => setIsDeleteDialogOpen(true)} className="text-red-600">
+  <Trash /> Delete Entity
+</DropdownMenuItem>
+
+// Dialog
+<ConfirmationDialog
+  open={isDeleteDialogOpen}
+  onOpenChange={setIsDeleteDialogOpen}
+  onConfirm={() => deleteEntity.mutate({ id })}
+  title="Delete Entity"
+  description="Are you sure? This cannot be undone."
+  confirmText="Delete"
+  confirmClassName="bg-red-600 hover:bg-red-700"
+  isLoading={deleteEntity.isPending}
+/>
+```
+
+---
+
+### 4. Create Form
+
+**Reference:** [CreateCasePage.tsx](../../packages/client/src/pages/CreateCasePage/CreateCasePage.tsx)
+
+#### Routing
+- Route: `/entities/:id` where `id` can be `'new'`
+- Conditional render: `{id === 'new' ? <CreatePage /> : <DetailPage />}`
+- Create button: `onClick={() => navigate('/entities/new')}`
+
+#### Form State
+```tsx
+const [field, setField] = useState('');
+const [validationErrors, setValidationErrors] = useState({});
+const [touched, setTouched] = useState(new Set());
+
+const createEntity = trpc.entity.create.useMutation({
+  onSuccess: (data) => {
+    utils.entity.list.invalidate();
+    navigate(`/entities/${data.id}`);
+  },
+});
+
+const handleSubmit = (e) => {
+  e.preventDefault();
+  setTouched(new Set(['field1', 'field2']));
+  if (!validate()) return;
+  createEntity.mutate({ field });
+};
+```
+
+#### Validation
+- Track touched fields: `touched.has(fieldName)`
+- Show errors only for touched fields
+- Validate on blur and submit
+- Red border: `className={touched.has('field') && errors.field ? 'border-red-500' : ''}`
+
+---
+
+### 5. Responsive Design
+
+#### Breakpoint
+- Mobile: default styles
+- Desktop: `lg:` prefix (≥ 1024px)
+
+#### Sidebar Pattern
+```tsx
+const [isSheetOpen, setIsSheetOpen] = useState(false);
+
+// Desktop sidebar
+<div className="hidden lg:block"><EntityList /></div>
+
+// Mobile sheet
+<Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
+  <EntityList onItemClick={() => setIsSheetOpen(false)} />
+</Sheet>
+
+// Menu button for mobile
+<Button onClick={() => setIsSheetOpen(true)} className="lg:hidden">
+  <List />
+</Button>
+```
+
+---
+
+### 6. States (Loading/Error/Empty)
+
+#### Loading
+```tsx
+if (isLoading) return (
+  <Skeleton className="h-5 w-3/4" />
+  // Match final content shape
+);
+```
+
+#### Error
+```tsx
+if (error) return (
+  <>
+    <p className="text-red-600">Error: {error.message}</p>
+    <Button onClick={() => refetch()}>Retry</Button>
+  </>
+);
+```
+
+#### Empty
+```tsx
+if (!data || data.length === 0) return (
+  <p className="text-gray-500">No items found</p>
+);
+```
+
+---
+
+### Implementation Checklist
+
+- [ ] Sidebar list: 200px, create button, active states, mobile sheet
+- [ ] Inline editing: Use EditableTitle/EditableSelect components
+- [ ] Delete: ConfirmationDialog with red styling
+- [ ] Create: Form at `/entity/new` with validation and touched state
+- [ ] Optimistic updates: onMutate/onError rollback pattern
+- [ ] Responsive: Mobile sheet overlay, desktop always visible
+- [ ] States: Loading skeletons, error retry, empty messaging
+- [ ] Navigation: To list after delete, to detail after create
+- [ ] Cache: Invalidate list.invalidate() and getById.invalidate()

--- a/packages/server/CLAUDE.md
+++ b/packages/server/CLAUDE.md
@@ -1,0 +1,168 @@
+# @carton/server Package Instructions
+
+This package contains the Express/tRPC backend server.
+
+## Package Purpose
+
+- **tRPC Router**: API endpoint definitions with type inference
+- **Database Operations**: All Prisma queries and mutations
+- **Business Logic**: Server-side validation and processing
+- **Authentication**: User session and auth middleware
+
+## Directory Structure
+
+```
+packages/server/
+├── src/
+│   ├── index.ts           # Express server setup, exports AppRouter
+│   ├── router.ts          # tRPC router definitions
+│   ├── trpc.ts            # tRPC initialization and procedures
+│   ├── context.ts         # Request context (Prisma, user)
+│   └── middleware/        # Express middleware
+│       └── autoLogin.ts
+├── db/
+│   ├── dev.db             # SQLite database file
+│   ├── seed.ts            # Database seeding script
+│   └── constants.ts       # Seed data constants
+├── package.json
+└── tsconfig.json
+```
+
+## Key Exports
+
+### From `@carton/server`
+```typescript
+export type { AppRouter } from './router.js';
+```
+
+The `AppRouter` type is the key export - it enables end-to-end type safety with the client.
+
+## Creating tRPC Procedures
+
+### Basic Query
+```typescript
+import { z } from 'zod';
+import { router, publicProcedure } from './trpc.js';
+
+export const appRouter = router({
+  entity: router({
+    list: publicProcedure.query(async ({ ctx }) => {
+      return ctx.prisma.entity.findMany();
+    }),
+    
+    getById: publicProcedure
+      .input(z.object({ id: z.string() }))
+      .query(async ({ ctx, input }) => {
+        return ctx.prisma.entity.findUnique({
+          where: { id: input.id },
+        });
+      }),
+  }),
+});
+```
+
+### Mutation with Auth Check
+```typescript
+create: publicProcedure
+  .input(z.object({
+    title: z.string().min(1),
+    description: z.string().min(1),
+  }))
+  .mutation(async ({ ctx, input }) => {
+    if (!ctx.userId) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'Not authenticated',
+      });
+    }
+    
+    return ctx.prisma.entity.create({
+      data: {
+        ...input,
+        createdBy: ctx.userId,
+      },
+    });
+  }),
+```
+
+## Import Rules
+
+This package CAN import from:
+- `@carton/shared` - Prisma client, schemas, utilities
+- `zod` - Input validation
+- `@trpc/server` - tRPC utilities
+- `express` - Server framework
+
+This package should NOT import from:
+- `@carton/client` - Would create circular dependency
+
+## Using Shared Schemas
+
+Import Zod schemas from shared for input validation:
+
+```typescript
+import { casePrioritySchema, caseStatusSchema } from '@carton/shared';
+
+update: publicProcedure
+  .input(z.object({
+    id: z.string(),
+    status: caseStatusSchema.optional(),
+    priority: casePrioritySchema.optional(),
+  }))
+  .mutation(async ({ ctx, input }) => {
+    // ...
+  }),
+```
+
+## Context
+
+The tRPC context provides:
+- `ctx.prisma` - PrismaClient instance
+- `ctx.userId` - Current user ID (from cookie/session)
+
+## Error Handling
+
+Use tRPC errors for proper HTTP status codes:
+
+```typescript
+import { TRPCError } from '@trpc/server';
+
+// 401 Unauthorized
+throw new TRPCError({
+  code: 'UNAUTHORIZED',
+  message: 'Not authenticated',
+});
+
+// 404 Not Found
+throw new TRPCError({
+  code: 'NOT_FOUND', 
+  message: 'Resource not found',
+});
+
+// 400 Bad Request
+throw new TRPCError({
+  code: 'BAD_REQUEST',
+  message: 'Invalid input',
+});
+```
+
+## Database Commands
+
+Run from project root:
+- `npm run db:generate` - Generate Prisma Client
+- `npm run db:push` - Push schema to database
+- `npm run db:seed` - Seed with test data
+- `npm run db:studio` - Open Prisma Studio
+
+## Adding a New Entity
+
+1. Add Prisma model in `packages/shared/prisma/schema.prisma`
+2. Run `npm run db:generate` then `npm run db:push`
+3. Add router procedures in `src/router.ts`
+4. Add seed data in `db/seed.ts` if needed
+
+## Production Considerations
+
+- Server uses `tsx` to run TypeScript directly (dev and prod)
+- Static files served from `packages/client/dist` in production
+- Database migrations via `prisma db push` at container startup

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -1,0 +1,104 @@
+# @carton/shared Package Instructions
+
+This package contains shared code used by both server and client packages.
+
+## Package Purpose
+
+- **Prisma schema**: Single source of truth for data models
+- **Generated types**: Zod schemas auto-generated from Prisma
+- **Utilities**: Helper functions safe for both server and browser
+- **Constants**: Shared constants and options
+
+## Directory Structure
+
+```
+packages/shared/
+├── prisma/
+│   └── schema.prisma      # Prisma schema (THE source of truth)
+├── src/
+│   ├── index.ts           # Main entry (server-safe, full exports)
+│   ├── client.ts          # Browser-safe entry (no Prisma runtime)
+│   ├── prisma.ts          # PrismaClient instance
+│   ├── types.ts           # Type definitions and schemas
+│   ├── utils.ts           # Utility functions
+│   └── generated/         # Auto-generated Zod schemas
+│       └── index.ts
+└── package.json
+```
+
+## Two Entry Points
+
+### `@carton/shared` (index.ts)
+Full exports including Prisma. **Server-only**.
+
+Exports:
+- `prisma` - PrismaClient instance
+- All Zod schemas from generated/
+- All types and utilities
+
+### `@carton/shared/client` (client.ts)
+Browser-safe exports. **No Prisma runtime**.
+
+Exports:
+- Zod enum schemas (CasePrioritySchema, CaseStatusSchema)
+- Type aliases (CasePriority, CaseStatus)
+- UI constants (CASE_PRIORITY_OPTIONS, CASE_STATUS_OPTIONS)
+- Utility functions (formatDate, formatCaseNumber)
+
+## Adding Code to This Package
+
+### New Utility Function
+
+1. Add to `src/utils.ts`
+2. Export from `src/index.ts`
+3. If browser-safe, also export from `src/client.ts`
+
+### New Type or Schema
+
+1. If based on Prisma: It's auto-generated, just re-export
+2. If custom: Add to `src/types.ts`, export from both entry points if browser-safe
+
+### New Prisma Model
+
+1. Add model to `prisma/schema.prisma`
+2. Run `npm run db:generate` from project root
+3. Generated Zod schemas appear in `src/generated/index.ts`
+
+## What NOT to Put Here
+
+- ❌ Server-specific logic (put in @carton/server)
+- ❌ React components (put in @carton/client)
+- ❌ API route definitions (put in @carton/server)
+- ❌ Types that depend on AppRouter (creates circular dependency)
+
+## Import Rules
+
+This package should NOT import from:
+- `@carton/server` - Would create circular dependency
+- `@carton/client` - Would create circular dependency
+
+This package CAN import from:
+- `zod` - For schema definitions
+- `@prisma/client` - For Prisma types and client
+
+## Generated Code
+
+The `src/generated/` directory contains auto-generated Zod schemas from `zod-prisma-types`.
+
+**Never edit files in generated/ manually** - they will be overwritten.
+
+To regenerate:
+```bash
+npm run db:generate
+```
+
+## Browser Compatibility
+
+Code in `client.ts` must be browser-safe:
+- ✅ Pure functions
+- ✅ Type definitions
+- ✅ Zod schemas (they work in browser)
+- ✅ Constants
+- ❌ PrismaClient
+- ❌ Node.js APIs
+- ❌ File system access


### PR DESCRIPTION
## Summary
- migrate agent definitions from `.github/agents` into `.claude/agents`
- migrate skill definitions and support docs into `.claude/skills`
- add Claude instruction files at root and package level (`CLAUDE.md`)


This PR focuses on Claude-compatible structure and naming for agents/skills/instructions