### PR TITLE
chore(agent): harden review-jira-ticket agent instructions

### DIFF
--- a/.github/agents/review-jira-ticket.agent.md
+++ b/.github/agents/review-jira-ticket.agent.md
@@ -99,8 +99,8 @@ Format the comment as follows. Only include categories where you found something
 ## Scope Analysis
 
 ### In Scope (as understood)
-- ☐ [Concrete thing the ticket covers]
-- ☐ [Another concrete thing]
+- ☐ [Concrete thing the ticket covers that needs to be built]
+- ✅ [Concrete thing the ticket covers that is already solved by an existing implementation]
 
 ### Out of Scope (as understood)
 - ☐ [Thing explicitly excluded or implied to be out]


### PR DESCRIPTION
## Summary

Hardens the `review-jira-ticket` agent harness to prevent implementation drift and clarify its exact workflow.

## Changes

- Enforces strict read-only + Jira-comment-only role with explicit forbidden actions list
- Removes the `review-log.md` write step that was triggering coding-mode behavior
- Updates workflow to close both the GitHub issue (Step 5) and pull request (Step 6) after posting Jira questions
- Adds `✅` symbol to Scope Analysis format for items already solved by existing implementation
- Aligns `tools` frontmatter to `github-mcp-server/*` for correct tool scoping
- Updates description and stop condition to reflect the full workflow