### PR TITLE
feat(obra): Add Avatar component

### DIFF
--- a/.agents/skills/conventional-commit/SKILL.md
+++ b/.agents/skills/conventional-commit/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: conventional-commit
+description: Create conventional commit messages following best conventions. Use when committing code changes, writing commit messages, or formatting git history. Follows conventional commits specification.
+license: MIT
+metadata:
+  version: "1.0.0"
+---
+
+# Conventional Commit Messages
+
+Follow these conventions when creating commits.
+
+## Prerequisites
+
+Before committing, ensure you're working on a feature branch, not the main branch.
+
+```bash
+# Check current branch
+git branch --show-current
+```
+
+If you're on `main` or `master`, create a new branch first:
+
+```bash
+# Create and switch to a new branch
+git checkout -b <type>/<short-description>
+```
+
+Branch naming should follow the pattern: `<type>/<short-description>` where type matches the commit type (e.g., `feat/add-user-auth`, `fix/null-pointer-error`, `refactor/extract-validation`).
+
+## Format
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+The header is required. Scope is optional. All lines must stay under 100 characters.
+
+## Commit Types
+
+| Type | Purpose |
+|------|---------|
+| `build` | Build system or CI changes |
+| `chore` | Routine maintenance tasks |
+| `ci` | Continuous integration configuration |
+| `deps` | Dependency updates |
+| `docs` | Documentation changes |
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `perf` | Performance improvement |
+| `refactor` | Code refactoring (no behavior change) |
+| `revert` | Revert a previous commit |
+| `style` | Code style and formatting |
+| `test` | Tests added, updated or improved |
+
+## Subject Line Rules
+
+- Use imperative, present tense: "Add feature" not "Added feature"
+- Capitalize the first letter
+- No period at the end
+- Maximum 70 characters
+
+## Body Guidelines
+
+- Explain **what** and **why**, not how
+- Use imperative mood and present tense
+- Include motivation for the change
+- Contrast with previous behavior when relevant
+
+## Conventional Commits
+The commit contains the following structural elements, to communicate intent to the consumers of your library:
+
+- fix: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
+- feat: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
+- BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
+- types other than fix: and feat: are allowed, for example @commitlint/config-conventional (based on the Angular convention) recommends build:, chore:, ci:, docs:, style:, refactor:, perf:, test:, and others.
+- footers other than BREAKING CHANGE: <description> may be provided and follow a convention similar to git trailer format.
+
+
+## Examples
+
+### Simple fix
+
+```
+fix(api): Handle null response in user endpoint
+
+The user API could return null for deleted accounts, causing a crash
+in the dashboard. Add null check before accessing user properties.
+```
+
+### Feature with scope
+
+```
+feat(alerts): Add Slack thread replies for alert updates
+
+When an alert is updated or resolved, post a reply to the original
+Slack thread instead of creating a new message. This keeps related
+notifications grouped together.
+```
+
+### Refactor
+
+```
+refactor: Extract common validation logic to shared module
+
+Move duplicate validation code from three endpoints into a shared
+validator class. No behavior change.
+```
+
+### Breaking change
+
+```
+feat(api)!: Remove deprecated v1 endpoints
+
+Remove all v1 API endpoints that were deprecated in version 23.1.
+Clients should migrate to v2 endpoints.
+
+BREAKING CHANGE: v1 endpoints no longer available
+```
+
+## Revert Format
+
+```
+revert: feat(api): Add new endpoint
+
+This reverts commit abc123def456.
+
+Reason: Caused performance regression in production.
+```
+
+## Principles
+
+- Each commit should be a single, stable change
+- Commits should be independently reviewable
+- The repository should be in a working state after each commit
+
+## References
+
+- [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: create-pr
+description: Create Pull Requests following best conventions. Use when opening PRs, writing PR descriptions, or preparing changes for review.
+license: MIT
+compatibility: Requires GitHub CLI (gh) authenticated and available
+metadata:
+  version: "1.1.0"
+---
+
+# Create Pull Request
+
+Create pull requests following the best engineering practices.
+
+**Requires**: GitHub CLI (`gh`) authenticated and available.
+
+## Prerequisites
+
+Before creating a PR, ensure all changes are committed. If there are uncommitted changes, run the commit skill `skill({ name: "conventional-commit" })` first to commit them properly.
+
+```bash
+# Check for uncommitted changes
+git status --porcelain
+```
+
+If the output shows any uncommitted changes (modified, added, or untracked files that should be included), invoke the commit skill `skill({ name: "conventional-commit" })` before proceeding.
+
+## Process
+
+### Step 1: Verify Branch State
+
+```bash
+# Detect the default branch
+BASE=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+
+# Check current branch and status
+git status
+git log $BASE..HEAD --oneline
+```
+
+Ensure:
+- All changes are committed
+- Branch is up to date with remote
+- Changes are rebased on the base branch if needed
+
+### Step 2: Analyze Changes
+
+Review what will be included in the PR:
+
+```bash
+# See all commits that will be in the PR
+git log $BASE..HEAD
+
+# See the full diff
+git diff $BASE...HEAD
+```
+
+Understand the scope and purpose of all changes before writing the description.
+
+### Step 3: Write the PR Description
+
+Use this structure for PR descriptions (ignoring any repository PR templates):
+
+```markdown
+<brief description of what the PR does>
+
+<why these changes are being made - the motivation>
+
+<alternative approaches considered, if any>
+
+<any additional context reviewers need>
+```
+
+**Do NOT include:**
+- "Test plan" sections
+- Checkbox lists of testing steps
+- Redundant summaries of the diff
+
+**Do include:**
+- Clear explanation of what and why
+- Links to relevant issues or tickets (only if available)
+- Context that isn't obvious from the code
+- Notes on specific areas that need careful review
+
+### Step 4: Create the PR
+
+```bash
+gh pr create --draft --title "<type>(<scope>): <description>" --body "
+<description body here>
+"
+```
+
+**Title format** follows commit conventions:
+- `feat(scope): Add new feature`
+- `fix(scope): Fix the bug`
+- `refactor(scope): Refactor something`
+
+## PR Description Examples
+
+### Feature PR
+
+```markdown
+Add Slack thread replies for alert notifications
+
+When an alert is updated or resolved, we now post a reply to the original
+Slack thread instead of creating a new message. This keeps related
+notifications grouped and reduces channel noise.
+
+Previously considered posting edits to the original message, but threading
+better preserves the timeline of events and works when the original message
+is older than Slack's edit window.
+```
+
+### Bug Fix PR
+
+```markdown
+Handle null response in user API endpoint
+
+The user endpoint could return null for soft-deleted accounts, causing
+dashboard crashes when accessing user properties. This adds a null check
+and returns a proper 404 response.
+
+```
+
+### Refactor PR
+
+```markdown
+Extract validation logic to shared module
+
+Moves duplicate validation code from the alerts, issues, and projects
+endpoints into a shared validator class. No behavior change.
+
+This prepares for adding new validation rules without
+duplicating logic across endpoints.
+```
+
+## Guidelines
+
+- **One PR per feature/fix** - Don't bundle unrelated changes
+- **Keep PRs reviewable** - Smaller PRs get faster, better reviews
+- **Explain the why** - Code shows what; description explains why
+- **Mark WIP early** - Use draft PRs for early feedback
+
+## Editing Existing PRs
+
+When updating a PR after creation, the skill automatically selects the best approach based on your GitHub CLI version:
+
+- **gh 2.82.1+**: Uses native `gh pr edit` (clean, full-featured)
+- **gh < 2.82.1**: Falls back to `gh api` (avoids Projects classic deprecation bug)
+
+### Check Your Version
+
+```bash
+# Check GitHub CLI version
+gh --version
+```
+
+### Modern Approach (gh 2.82.1+)
+
+```bash
+# Update PR description
+gh pr edit PR_NUMBER --body "Updated description here"
+
+# Update PR title
+gh pr edit PR_NUMBER --title "New Title here"
+
+# Update both
+gh pr edit PR_NUMBER --title "new: Title" --body "New description"
+```
+
+### Legacy Fallback (gh < 2.82.1)
+
+If `gh pr edit` fails with a "Projects (classic) is being deprecated" error, use the API directly:
+
+```bash
+# Update PR description
+gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER -f body="
+Updated description here
+"
+
+# Update PR title
+gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER -f title='New Title here'
+
+# Update both
+gh api -X PATCH repos/{owner}/{repo}/pulls/PR_NUMBER \
+  -f title='new: Title' \
+  -f body='New description'
+```
+
+**Note**: The Projects (classic) bug was fixed in gh 2.82.1 (October 2025). Upgrade with your package manager if you're on an older version.

--- a/.claude/skills/conventional-commit
+++ b/.claude/skills/conventional-commit
@@ -1,0 +1,1 @@
+../../.agents/skills/conventional-commit

--- a/.claude/skills/create-pr
+++ b/.claude/skills/create-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/create-pr

--- a/packages/client/src/components/obra/Avatar/Avatar.stories.tsx
+++ b/packages/client/src/components/obra/Avatar/Avatar.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Avatar } from './Avatar';
+
+const meta: Meta<typeof Avatar> = {
+  component: Avatar,
+  title: 'Obra/Avatar',
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Avatar size',
+    },
+    src: { control: 'text', description: 'Image source URL' },
+    alt: { control: 'text', description: 'Image alt text' },
+    fallback: { control: 'text', description: 'Text shown when no image' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Avatar>;
+
+export const WithFallback: Story = {
+  args: {
+    fallback: 'JD',
+    alt: 'John Doe',
+  },
+};
+
+export const WithImage: Story = {
+  args: {
+    src: 'https://i.pravatar.cc/80',
+    alt: 'User avatar',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    fallback: 'AB',
+    size: 'sm',
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    fallback: 'AB',
+    size: 'md',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    fallback: 'AB',
+    size: 'lg',
+  },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Avatar fallback="AB" size="sm" />
+      <Avatar fallback="AB" size="md" />
+      <Avatar fallback="AB" size="lg" />
+    </div>
+  ),
+};

--- a/packages/client/src/components/obra/Avatar/Avatar.test.tsx
+++ b/packages/client/src/components/obra/Avatar/Avatar.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Avatar } from './Avatar';
+
+describe('Avatar', () => {
+  describe('Fallback rendering', () => {
+    it('should render fallback text when no src', () => {
+      render(<Avatar fallback="JD" />);
+      expect(screen.getByText('JD')).toBeInTheDocument();
+    });
+
+    it('should render "?" when no src and no fallback', () => {
+      render(<Avatar />);
+      expect(screen.getByText('?')).toBeInTheDocument();
+    });
+  });
+
+  describe('Image rendering', () => {
+    it('should render an img when src is provided', () => {
+      render(<Avatar src="https://example.com/avatar.jpg" alt="Test user" />);
+      expect(screen.getByRole('img')).toBeInTheDocument();
+    });
+
+    it('should fall back to fallback text on image error', () => {
+      render(<Avatar src="bad-url.jpg" fallback="JD" alt="Test user" />);
+      fireEvent.error(screen.getByRole('img'));
+      expect(screen.getByText('JD')).toBeInTheDocument();
+    });
+  });
+
+  describe('Sizes', () => {
+    it('should apply sm size classes', () => {
+      const { container } = render(<Avatar fallback="AB" size="sm" />);
+      expect(container.firstChild).toHaveClass('size-6');
+    });
+
+    it('should apply md size classes by default', () => {
+      const { container } = render(<Avatar fallback="AB" />);
+      expect(container.firstChild).toHaveClass('size-8');
+    });
+
+    it('should apply lg size classes', () => {
+      const { container } = render(<Avatar fallback="AB" size="lg" />);
+      expect(container.firstChild).toHaveClass('size-10');
+    });
+  });
+
+  describe('Custom className', () => {
+    it('should apply custom className', () => {
+      const { container } = render(<Avatar fallback="AB" className="ring-2" />);
+      expect(container.firstChild).toHaveClass('ring-2');
+    });
+  });
+});

--- a/packages/client/src/components/obra/Avatar/Avatar.tsx
+++ b/packages/client/src/components/obra/Avatar/Avatar.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+import type { AvatarProps } from './types';
+
+const sizeClasses = {
+  sm: 'size-6 text-xs',
+  md: 'size-8 text-sm',
+  lg: 'size-10 text-base',
+};
+
+export function Avatar({ src, alt, fallback, size = 'md', className }: AvatarProps) {
+  const [imgError, setImgError] = useState(false);
+
+  const showImage = src && !imgError;
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center justify-center rounded-full bg-muted text-muted-foreground font-medium overflow-hidden shrink-0',
+        sizeClasses[size],
+        className
+      )}
+    >
+      {showImage ? (
+        <img
+          src={src}
+          alt={alt ?? ''}
+          className="size-full object-cover"
+          onError={() => setImgError(true)}
+        />
+      ) : (
+        <span aria-label={alt}>{fallback ?? '?'}</span>
+      )}
+    </span>
+  );
+}

--- a/packages/client/src/components/obra/Avatar/index.ts
+++ b/packages/client/src/components/obra/Avatar/index.ts
@@ -1,0 +1,2 @@
+export { Avatar } from './Avatar';
+export type { AvatarProps } from './types';

--- a/packages/client/src/components/obra/Avatar/types.ts
+++ b/packages/client/src/components/obra/Avatar/types.ts
@@ -1,0 +1,7 @@
+export interface AvatarProps {
+  src?: string;
+  alt?: string;
+  fallback?: string;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}

--- a/packages/client/src/components/obra/index.ts
+++ b/packages/client/src/components/obra/index.ts
@@ -1,3 +1,6 @@
+export { Avatar } from './Avatar';
+export type { AvatarProps } from './Avatar';
+
 export {
   Accordion,
   AccordionItem,

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "skills": {
+    "conventional-commit": {
+      "source": "marcelorodrigo/agent-skills",
+      "sourceType": "github",
+      "computedHash": "c09073f3bb5141fcefa8347051035c23ac2a87774ac3b1dec2a2afa583820dcf"
+    },
+    "create-pr": {
+      "source": "marcelorodrigo/agent-skills",
+      "sourceType": "github",
+      "computedHash": "ea544fafe229b0f517fd5b5f06166290edb1dd237de2aedf014f6b3b38fda9e4"
+    }
+  }
+}


### PR DESCRIPTION
Add a simple Avatar component to the obra UI library.

Renders a circular avatar with image support and text fallback. When the image fails to load or no `src` is provided, it shows the `fallback` text (or `?`). Supports three sizes — `sm`, `md`, `lg` — via Tailwind.

Follows the same modlet structure as the rest of the obra components: component, types, index, tests, and Storybook stories.