### PR TITLE
Update app title to Bitovi Case Management

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Carton Case Management</title>
+  <title>Bitovi Case Management</title>
 </head>
 
 <body>

--- a/packages/client/src/components/Header/Header.tsx
+++ b/packages/client/src/components/Header/Header.tsx
@@ -5,7 +5,7 @@ import CartonLogoSvg from '@/assets/carton-logo.svg';
 import type { HeaderProps } from './types';
 
 function CartonLogo({ size = 34 }: { size?: number }) {
-  return <img src={CartonLogoSvg} alt="Carton Case Management" width={size} height={size} />;
+  return <img src={CartonLogoSvg} alt="Bitovi Case Management" width={size} height={size} />;
 }
 
 export function Header({ className, userInitials = 'AM', onAvatarClick }: HeaderProps) {
@@ -21,7 +21,7 @@ export function Header({ className, userInitials = 'AM', onAvatarClick }: Header
       >
         <CartonLogo />
         <span className="text-white text-xl font-semibold">
-          Carton<span className="hidden lg:inline"> Case Management</span>
+          Bitovi<span className="hidden lg:inline"> Case Management</span>
         </span>
       </Link>
 


### PR DESCRIPTION
This PR updates the application title from the default to "Bitovi Case Management" to better reflect the application's branding.

## Changes
- Updated `<title>` tag in `packages/client/index.html` to "Bitovi Case Management"

## Testing
- Verify the browser tab title displays "Bitovi Case Management" when the app is loaded