### PR TITLE
Add bitovi-platform-services deployment (new files only)

### DIFF
--- a/.github/workflows/platform-release.yml
+++ b/.github/workflows/platform-release.yml
@@ -1,0 +1,92 @@
+# Platform CI — new file, separate from ci.yml/deploy.yaml/deploy-prod.yaml/
+# deploy-staging.yaml, which keep serving the legacy ECS pipeline untouched
+# on their own triggers.
+#
+# Two-job staging/production model (bitovi-platform-services
+# docs/operations/staging-rollout.md, Phase 2.5), since this app onboards
+# with both a staging and a production Application from day one:
+#   - Every merge to main: build a SHA-tagged image, point the staging
+#     Application at it (deploy/staging/values.yaml).
+#   - Every vX.Y.Z tag: promote the exact digest staging already validated
+#     to production (deploy/production/values.yaml) — no rebuild.
+#
+# The ECR repository, OIDC push role, and CI secrets (ECR_PUSH_ROLE_ARN,
+# ECR_REPOSITORY) are created by the platform via the production
+# Application and pushed into this repo's Actions secrets automatically —
+# nothing to configure by hand. Staging reuses production's ECR repo; it
+# has no shared tier of its own.
+
+name: Platform release
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: platform-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  # Every merge to main.
+  staging:
+    if: github.ref_type == 'branch'
+    needs: [test]
+    uses: bitovi/platform-ci/.github/workflows/container-build.yml@0.0.1
+    permissions:
+      id-token: write
+      contents: write
+      actions: write
+    with:
+      values-file: deploy/staging/values.yaml
+      image-tag-path: .workloads.main.image.tag
+      writeback-app-id: ${{ vars.CI_WRITEBACK_APP_ID }}
+      environment-label: staging
+    secrets: inherit
+
+  # Every vX.Y.Z tag: promote the digest staging already validated.
+  production:
+    if: github.ref_type == 'tag'
+    needs: [test]
+    uses: bitovi/platform-ci/.github/workflows/container-promote.yml@0.0.1
+    permissions:
+      id-token: write
+      contents: write
+      actions: write
+    with:
+      values-file: deploy/production/values.yaml
+      source-values-file: deploy/staging/values.yaml
+      image-tag-path: .workloads.main.image.tag
+      writeback-app-id: ${{ vars.CI_WRITEBACK_APP_ID }}
+    secrets: inherit
+
+  notify:
+    name: Slack Notification
+    needs: [test, staging, production]
+    if: always()
+    uses: ./.github/workflows/platform-slack-notification.yml
+    with:
+      status: ${{ !contains(needs.*.result, 'failure') && 'success' || 'failure' }}
+      service_name: "carton-case-management"
+      environment: ${{ github.ref_type == 'tag' && 'production' || 'staging' }}
+      title: ${{ !contains(needs.*.result, 'failure') && 'platform deploy succeeded' || 'platform deploy failed' }}
+      detail: "Ref: ${{ github.ref_name }}"
+    secrets:
+      # A repo-level SLACK_WEBHOOK_URL wins; otherwise the org-level default
+      # applies, so this notifies with no per-repo setup needed.
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL || secrets.BITOVI_PLATFORM_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/platform-slack-notification.yml
+++ b/.github/workflows/platform-slack-notification.yml
@@ -1,0 +1,75 @@
+# Reusable Slack notifier for platform-release.yml — canonical copy from
+# add-app's templates. New file; nothing existing references or is affected
+# by it.
+
+name: Platform Slack Notification
+
+on:
+  workflow_call:
+    inputs:
+      status:
+        description: "Outcome status: 'success' or 'failure'"
+        required: true
+        type: string
+      service_name:
+        description: "Service name displayed in the notification"
+        required: true
+        type: string
+      environment:
+        description: "Deployment environment (e.g. staging, production)"
+        required: true
+        type: string
+      title:
+        description: "Main notification message line without emoji"
+        required: true
+        type: string
+      detail:
+        description: "Optional second line of detail"
+        required: false
+        type: string
+        default: ""
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack Notification (with detail)
+        if: inputs.detail != ''
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "<${{ github.server_url }}/${{ github.repository }}|${{ inputs.service_name }}> *${{ inputs.environment }}* ${{ inputs.title }} ${{ inputs.status == 'success' && ':white_check_mark:' || ':x:' }}"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "${{ inputs.detail }}"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "> Check the logs for <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|details>."
+
+      - name: Send Slack Notification
+        if: inputs.detail == ''
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "<${{ github.server_url }}/${{ github.repository }}|${{ inputs.service_name }}> *${{ inputs.environment }}* ${{ inputs.title }} ${{ inputs.status == 'success' && ':white_check_mark:' || ':x:' }}"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "> Check the logs for <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|details>."

--- a/Dockerfile.platform
+++ b/Dockerfile.platform
@@ -1,0 +1,53 @@
+# Production image for the bitovi-platform-services deployment.
+#
+# New file — does not modify Dockerfile, Dockerfile.aws, or Dockerfile.original,
+# which stay exactly as they are for local/devcontainer training use and the
+# legacy ECS pipeline. Based on the shape of Dockerfile.original (already
+# correct in spirit: multi-stage, NODE_ENV=production, Express serves the
+# built client + a real /health route) with three fixes: runs as a non-root
+# user, copies node_modules wholesale from the builder instead of a
+# workspace-scoped --omit=dev reinstall (the `prisma` CLI is a devDependency
+# of @carton/shared — omitting dev deps would leave `npx prisma db push` with
+# nothing local to run and force a network fetch on every container start),
+# and drops the unused dev/storybook/playwright ports from EXPOSE.
+
+FROM node:24-alpine AS builder
+WORKDIR /app
+
+COPY package*.json ./
+COPY packages/shared/package*.json ./packages/shared/
+COPY packages/server/package*.json ./packages/server/
+COPY packages/client/package*.json ./packages/client/
+
+RUN npm ci
+
+COPY . .
+
+RUN npx prisma generate --schema=packages/shared/prisma/schema.prisma && npm run build
+
+FROM node:24-alpine
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3001
+ENV HOST=0.0.0.0
+ENV DATABASE_URL=file:/app/packages/server/db/prod.db
+
+COPY --from=builder --chown=node:node /app/node_modules ./node_modules
+COPY --from=builder --chown=node:node /app/package.json ./package.json
+COPY --from=builder --chown=node:node /app/packages/server/package.json ./packages/server/package.json
+COPY --from=builder --chown=node:node /app/packages/server/src ./packages/server/src
+COPY --from=builder --chown=node:node /app/packages/server/db ./packages/server/db
+COPY --from=builder --chown=node:node /app/packages/shared/package.json ./packages/shared/package.json
+COPY --from=builder --chown=node:node /app/packages/shared/src ./packages/shared/src
+COPY --from=builder --chown=node:node /app/packages/shared/prisma ./packages/shared/prisma
+COPY --from=builder --chown=node:node /app/packages/client/dist ./packages/client/dist
+
+USER node
+
+EXPOSE 3001
+
+# Fresh SQLite file pushed + reseeded on every container start — the
+# intended behavior for this training demo (confirmed with the app owner),
+# not a workaround.
+CMD sh -c "npx prisma db push --schema=packages/shared/prisma/schema.prisma --skip-generate && cd packages/server && npx tsx db/seed.ts && npm run start:prod"

--- a/deploy/production/values.yaml
+++ b/deploy/production/values.yaml
@@ -1,0 +1,28 @@
+# carton-case-management — PRODUCTION.
+#
+# The platform app interface: one file describing the whole app (spec:
+# bitovi-platform-services/charts/interface.yaml). Its staging counterpart is
+# deploy/staging/values.yaml — two complete files rather than a base plus an
+# overlay, so each environment reads exactly one file and there are no merge
+# semantics to reason about.
+#
+# Absence of `env:` at the top level is what marks this as production: it
+# owns the shared tier (the ECR repository, the CI push role, the ESO
+# secret push-back) that staging reuses rather than duplicating.
+#
+# This app has no database dependency and no secrets — it's a training/demo
+# app whose SQLite data is intentionally ephemeral, reseeded with demo data
+# on every container start (confirmed with the app owner, not a gap).
+name: carton-case-management
+repo: bitovi/carton-case-management
+workloads:
+  main:
+    kind: server
+    port: 3001
+    health: /health
+    domain: carton-case-management.bitovi-tools.com
+    # Empty: the platform builds and hosts the image, CI fills the tag in on
+    # release. The app doesn't run until the first vX.Y.Z tag is pushed.
+    image: {}
+infra:
+  hostedZone: bitovi-tools-com

--- a/deploy/staging/values.yaml
+++ b/deploy/staging/values.yaml
@@ -1,0 +1,24 @@
+# carton-case-management — STAGING.
+#
+# A complete interface file, not an overlay: its production counterpart is
+# deploy/production/values.yaml. `env: staging` is what makes this staging,
+# and the platform derives the rest — namespace becomes
+# carton-case-management-staging, AWS resource names gain a -staging
+# segment, the Ingress joins the staging ALB, pods run at a negative
+# scheduling priority, and no shared tier renders (no ECR repo, no push
+# role, no CI secret push-back) — staging runs the exact image production
+# built.
+env: staging
+name: carton-case-management
+repo: bitovi/carton-case-management
+workloads:
+  main:
+    kind: server
+    port: 3001
+    health: /health
+    domain: carton-case-management-staging.bitovi-tools.com
+    # Written by CI on merge to main / promotion. Empty until the first
+    # staging build.
+    image: {}
+infra:
+  hostedZone: bitovi-tools-com


### PR DESCRIPTION
## What & why

Adds deployment config so this app can run on `bitovi-platform-services`
(EKS/GitOps) alongside its existing ECS Fargate deployment. Companion PR:
https://github.com/bitovi/bitovi-platform-services/pull/205 (adds the Argo
CD Applications + migration tracking doc).

Context: this app is Bitovi's internal AI-enablement training demo, not a
production business app (see `migration-tracking/carton-case-management.md`
in the companion PR for the full write-up). The legacy ECS deployment at
`carton.bitovi.tools` stays fully live and untouched — this stands up a
**new, separate** instance at new `bitovi-tools.com` domains for us to
verify before any training material or DNS gets updated.

## What's new (nothing existing is modified)

- `Dockerfile.platform` — a real production build. The Dockerfile currently
  live in ECS (`Dockerfile`/`Dockerfile.aws`) runs the Vite *dev* server
  (`npm run dev`, `NODE_ENV=development`) — fine for the local devcontainer
  training flow it was actually built for, but not something to run behind
  a production ALB. This new file is based on the shape of the already
  mostly-correct-but-unused `Dockerfile.original`: multi-stage build,
  `NODE_ENV=production`, Express serves the built client + the real
  `/health` route on port 3001. Fixed to run as non-root and to copy
  `node_modules` wholesale from the builder (the `prisma` CLI is a
  devDependency — trimming it out would force a network fetch on every
  container start).
- `deploy/production/values.yaml`, `deploy/staging/values.yaml` — the
  platform app-interface files (two complete files, following the current
  `rating-candidates` precedent). No database dependency, no secrets — this
  app's SQLite data is intentionally ephemeral, reseeded fresh on every
  container start (confirmed with the app owner as the intended design for
  a training demo, not a gap).
- `.github/workflows/platform-release.yml` +
  `platform-slack-notification.yml` — a new, separate CI path: build on
  every merge to `main` (updates staging), promote the exact validated
  digest to production on a `vX.Y.Z` tag. `ci.yml`, `deploy.yaml`,
  `deploy-prod.yaml`, and `deploy-staging.yaml` are untouched and keep
  serving the legacy ECS pipeline on their own triggers, unaffected by this.

**Known, deliberately deferred:** the hardcoded `environment: production` in
the legacy `deploy.yaml` (staging currently runs under prod's GitHub
Environment protection) is a real bug but is **not** fixed here — fixing it
means editing a file the still-live legacy pipeline depends on, out of
scope for this PR by request.

## Verification

- `docker build -f Dockerfile.platform` succeeded; `docker run` showed the
  schema push + reseed (6 users, 5 customers, 5 cases, 9 comments) followed
  by a clean server start.
- `curl /health` → `{"status":"ok"}`; `/` served the built SPA; a deep
  client route SPA-fell-back to 200; a real tRPC call (`case.list`)
  returned live seeded data; confirmed running as non-root (`whoami` →
  `node`).
- Both values files verified by rendering them through
  `helm template charts/interface` in `bitovi-platform-services` — correct
  port/health/domain, staging correctly skips the GitHub/ECR block.

## Risk / rollback

Purely additive — no existing file is modified (verified: `git diff main`
is empty aside from new files). The legacy ECS deployment, its domain, and
its CI keep running exactly as they do today regardless of what happens to
this PR. Rollback is deleting these new files / reverting the branch;
nothing else is affected.
